### PR TITLE
dynamicaly create load_path

### DIFF
--- a/lib/ruby_warrior/level.rb
+++ b/lib/ruby_warrior/level.rb
@@ -24,7 +24,11 @@ module RubyWarrior
     end
     
     def load_path
-      @profile.tower_path + "/level_" + @number.to_s.rjust(3, '0') + ".rb"
+      File.join(
+        File.expand_path(File.dirname(__FILE__) + '/../../towers/'),
+        File.basename(@profile.tower_path) + "/level_" +
+          @number.to_s.rjust(3, '0') + ".rb"
+      )
     end
     
     def load_level

--- a/lib/ruby_warrior/profile.rb
+++ b/lib/ruby_warrior/profile.rb
@@ -62,7 +62,7 @@ module RubyWarrior
     end
     
     def tower
-      Tower.new(@tower_path)
+      Tower.new(File.basename @tower_path)
     end
     
     def current_level

--- a/lib/ruby_warrior/tower.rb
+++ b/lib/ruby_warrior/tower.rb
@@ -3,7 +3,7 @@ module RubyWarrior
     attr_reader :path
     
     def initialize(path)
-      @path = path
+      @path = File.join(File.expand_path(File.dirname(__FILE__) + '/../../towers/'), path)
     end
     
     def name


### PR DESCRIPTION
Hi, I have a lot fun with ruby-warrior, however, I'm moving my files from one computer to another and current version doesn't support this. I've made few minor changes which creates path dynamicaly and is still compatible with current .profile.

Best regards,
Petr Kovar
