### PR TITLE
Fixed issue #38

### DIFF
--- a/spec/ruby_warrior/abilities/attack_spec.rb
+++ b/spec/ruby_warrior/abilities/attack_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::Attack do
   before(:each) do

--- a/spec/ruby_warrior/abilities/base_spec.rb
+++ b/spec/ruby_warrior/abilities/base_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::Base do
   before(:each) do

--- a/spec/ruby_warrior/abilities/bind_spec.rb
+++ b/spec/ruby_warrior/abilities/bind_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::Bind do
   before(:each) do

--- a/spec/ruby_warrior/abilities/direction_of_spec.rb
+++ b/spec/ruby_warrior/abilities/direction_of_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::DirectionOf do
   before(:each) do

--- a/spec/ruby_warrior/abilities/direction_of_stairs_spec.rb
+++ b/spec/ruby_warrior/abilities/direction_of_stairs_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::DirectionOfStairs do
   before(:each) do

--- a/spec/ruby_warrior/abilities/distance_of_spec.rb
+++ b/spec/ruby_warrior/abilities/distance_of_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::DistanceOf do
   before(:each) do

--- a/spec/ruby_warrior/abilities/explode_spec.rb
+++ b/spec/ruby_warrior/abilities/explode_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::Explode do
   before(:each) do

--- a/spec/ruby_warrior/abilities/feel_spec.rb
+++ b/spec/ruby_warrior/abilities/feel_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::Feel do
   before(:each) do

--- a/spec/ruby_warrior/abilities/form_spec.rb
+++ b/spec/ruby_warrior/abilities/form_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::Form do
   before(:each) do

--- a/spec/ruby_warrior/abilities/health_spec.rb
+++ b/spec/ruby_warrior/abilities/health_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::Health do
   before(:each) do

--- a/spec/ruby_warrior/abilities/listen_spec.rb
+++ b/spec/ruby_warrior/abilities/listen_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::Listen do
   before(:each) do

--- a/spec/ruby_warrior/abilities/look_spec.rb
+++ b/spec/ruby_warrior/abilities/look_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::Look do
   before(:each) do

--- a/spec/ruby_warrior/abilities/pivot_spec.rb
+++ b/spec/ruby_warrior/abilities/pivot_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::Pivot do
   before(:each) do

--- a/spec/ruby_warrior/abilities/rescue_spec.rb
+++ b/spec/ruby_warrior/abilities/rescue_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::Rescue do
   before(:each) do

--- a/spec/ruby_warrior/abilities/rest_spec.rb
+++ b/spec/ruby_warrior/abilities/rest_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::Rest do
   before(:each) do

--- a/spec/ruby_warrior/abilities/shoot_spec.rb
+++ b/spec/ruby_warrior/abilities/shoot_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::Shoot do
   before(:each) do

--- a/spec/ruby_warrior/abilities/throw_spec.rb
+++ b/spec/ruby_warrior/abilities/throw_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::Detonate do
   before(:each) do

--- a/spec/ruby_warrior/abilities/walk_spec.rb
+++ b/spec/ruby_warrior/abilities/walk_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Abilities::Walk do
   before(:each) do

--- a/spec/ruby_warrior/core_additions_spec.rb
+++ b/spec/ruby_warrior/core_additions_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require_relative '../spec_helper'
 
 describe String do
   it "should wrap text at white space when over a specific character length" do

--- a/spec/ruby_warrior/floor_spec.rb
+++ b/spec/ruby_warrior/floor_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require_relative '../spec_helper'
 
 describe RubyWarrior::Floor do
   describe "2x3" do

--- a/spec/ruby_warrior/game_spec.rb
+++ b/spec/ruby_warrior/game_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require_relative '../spec_helper'
 
 describe RubyWarrior::Game do
   before(:each) do

--- a/spec/ruby_warrior/level_loader_spec.rb
+++ b/spec/ruby_warrior/level_loader_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require_relative '../spec_helper'
 
 describe RubyWarrior::LevelLoader do
   describe "with profile" do

--- a/spec/ruby_warrior/level_spec.rb
+++ b/spec/ruby_warrior/level_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require_relative '../spec_helper'
 require 'set'
 
 describe RubyWarrior::Level do

--- a/spec/ruby_warrior/player_generator_spec.rb
+++ b/spec/ruby_warrior/player_generator_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require_relative '../spec_helper'
 
 describe RubyWarrior::PlayerGenerator do
   before(:each) do

--- a/spec/ruby_warrior/position_spec.rb
+++ b/spec/ruby_warrior/position_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require_relative '../spec_helper'
 
 describe RubyWarrior::Position do
   before(:each) do

--- a/spec/ruby_warrior/profile_spec.rb
+++ b/spec/ruby_warrior/profile_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require_relative '../spec_helper'
 
 describe RubyWarrior::Profile do
   before(:each) do

--- a/spec/ruby_warrior/space_spec.rb
+++ b/spec/ruby_warrior/space_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require_relative '../spec_helper'
 
 describe RubyWarrior::Space do
   before(:each) do

--- a/spec/ruby_warrior/tower_spec.rb
+++ b/spec/ruby_warrior/tower_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require_relative '../spec_helper'
 
 describe RubyWarrior::Tower do
   before(:each) do

--- a/spec/ruby_warrior/turn_spec.rb
+++ b/spec/ruby_warrior/turn_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require_relative '../spec_helper'
 
 describe RubyWarrior::Turn do
   describe "with actions" do

--- a/spec/ruby_warrior/ui_spec.rb
+++ b/spec/ruby_warrior/ui_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require_relative '../spec_helper'
 
 describe RubyWarrior::UI do
   before(:each) do

--- a/spec/ruby_warrior/units/archer_spec.rb
+++ b/spec/ruby_warrior/units/archer_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Units::Archer do
   before(:each) do

--- a/spec/ruby_warrior/units/base_spec.rb
+++ b/spec/ruby_warrior/units/base_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Units::Base do
   before(:each) do

--- a/spec/ruby_warrior/units/captive_spec.rb
+++ b/spec/ruby_warrior/units/captive_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Units::Captive do
   before(:each) do

--- a/spec/ruby_warrior/units/golem_spec.rb
+++ b/spec/ruby_warrior/units/golem_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Units::Golem do
   before(:each) do

--- a/spec/ruby_warrior/units/sludge_spec.rb
+++ b/spec/ruby_warrior/units/sludge_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Units::Sludge do
   before(:each) do

--- a/spec/ruby_warrior/units/thick_sludge_spec.rb
+++ b/spec/ruby_warrior/units/thick_sludge_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Units::ThickSludge do
   before(:each) do

--- a/spec/ruby_warrior/units/warrior_spec.rb
+++ b/spec/ruby_warrior/units/warrior_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 class Player
   def turn(warrior)

--- a/spec/ruby_warrior/units/wizard_spec.rb
+++ b/spec/ruby_warrior/units/wizard_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../../spec_helper'
+require_relative '../../spec_helper'
 
 describe RubyWarrior::Units::Wizard do
   before(:each) do


### PR DESCRIPTION
Just fixed issue #38, when specs weren't run correctly, `rake spec` failed with something like `spec/ruby_warrior/units/captive_spec.rb:1:in`require': no such file to load -- spec/ruby_warrior/units/../../spec_helper (LoadError)`

Now everything goes great `249 examples, 0 failures`
