### PR TITLE
.profile confusion

### DIFF
--- a/lib/ruby_warrior/game.rb
+++ b/lib/ruby_warrior/game.rb
@@ -4,7 +4,7 @@ module RubyWarrior
     def start
       UI.puts "Welcome to Ruby Warrior"
       
-      if File.exist?(Config.path_prefix + '/.profile')
+      if File.exist?(Config.path_prefix + '/.profile') and ENV['HOME'] != File.expand_path(Config.path_prefix)
         @profile = Profile.load(Config.path_prefix + '/.profile')
       else
         if File.exist?(Config.path_prefix + '/ruby-warrior')


### PR DESCRIPTION
Fixed a bug where if you tried to start the game with your operating system's '.profile' file (used for initializing your terminal's settings) that it would error out by trying to load that file instead of the proper '.profile' in the ruby-warrior's data directory.

The fix is it won't load the file if your $HOME directory is the same as the directory you're running ruby-warrior from.
