### PR TITLE
2 mistakes in level description fixed

### DIFF
--- a/towers/beginner/level_002.rb
+++ b/towers/beginner/level_002.rb
@@ -3,8 +3,8 @@
 #  --------
 
 description "It is too dark to see anything, but you smell sludge nearby."
-tip "Use warrior.feel.empty? to see if there's anything in front of you, and warrior.attack! to fight it. Remember, you can only do one action (ending in !) per turn."
-clue "Add an if/else condition using warrior.feel.empty? to decide whether to warrior.attack! or warrior.walk!."
+tip "Use warrior.feel.enemy? to see if there's anything in front of you, and warrior.attack! to fight it. Remember, you can only do one action (ending in !) per turn."
+clue "Add an if/else condition using warrior.feel.enemy? to decide whether to warrior.attack! or warrior.walk!."
 
 time_bonus 20
 ace_score 26


### PR DESCRIPTION
Fixed the irritating mistake in README file for beginner/level2. changed 2 times from ".empty?" to ".enemy?"
