### PR TITLE
Intermediate level 3 spelling mistake

### DIFF
--- a/towers/intermediate/level_003.rb
+++ b/towers/intermediate/level_003.rb
@@ -5,7 +5,7 @@
 #  ---
 
 description "You feel slime on all sides, you're surrounded!"
-tip "Call warrior.bind!(direction) to bind an enemy to keep him from attacking. Bound enemies look like capitves."
+tip "Call warrior.bind!(direction) to bind an enemy to keep him from attacking. Bound enemies look like captives."
 clue "Count the number of enemies around you, if there's two or more, bind one."
 
 time_bonus 50


### PR DESCRIPTION
Changed the tip, "... Bound enemies look like **capitves**." to "... captives".
