### PR TITLE
Tweak scoring goals

### DIFF
--- a/towers/beginner/level_006.rb
+++ b/towers/beginner/level_006.rb
@@ -7,7 +7,7 @@ tip "You can walk backward by passing ':backward' as an argument to walk!. Same 
 clue "Walk backward if you are taking damage from afar and do not have enough health to attack. You may also want to consider walking backward until warrior.feel(:backward).wall?."
 
 time_bonus 55
-ace_score 110
+ace_score 105
 size 8, 1
 stairs 7, 0
 


### PR DESCRIPTION
Level 6 has an ace score that I think is impossible to reach. An otherwise-generally-sound strategy scores only 107 on this particular level, and even choosing moves specifically for this level I can only get up to 109. I lowered the goal to 105, but if that's too easy 107 would also be reasonable. 

Further analysis of strategy follows if you're inclined to read it:

A good general strategy for saving time is to only rest as much
as necessary to defeat all enemies you have seen so far,
otherwise you will often waste time resting. On this level, that
means walking into an archer's range with only 2 health, and
stepping back for long enough to rest slows you down beyond the
ace score.

Even if you're generally cautious and always heal to 7+ (costing
yourself some time on other levels), that's still only 109 on this
one.

The only other plausible strategy I see is to defeat the slime, retreat to
heal up to 16 HP, and then bull-rush the archers. That scores 108, so
I'm not sure if it's even possible to score 110 here. If there's a way
I'd love to hear about it!
