### PR TITLE
fixing a typo

### DIFF
--- a/lib/ruby_warrior/abilities/explode.rb
+++ b/lib/ruby_warrior/abilities/explode.rb
@@ -9,7 +9,7 @@ module RubyWarrior
       
       def perform
         if @unit.position
-          @unit.say "explodes, collapsing the ceiling and damanging every unit."
+          @unit.say "explodes, collapsing the ceiling and damaging every unit."
           @unit.position.floor.units.map do |unit|
             unit.take_damage(100)
           end


### PR DESCRIPTION
Hello,

Just fixing a quick typo when a captive explodes.

Thanks!
