### PR TITLE
Fix tower path wildcard

### DIFF
--- a/lib/ruby_warrior/game.rb
+++ b/lib/ruby_warrior/game.rb
@@ -156,7 +156,7 @@ module RubyWarrior
     end
     
     def tower_paths
-      Dir[File.expand_path('../../../towers/*', __FILE__)]
+      Dir[File.expand_path('../../../towers', __FILE__) + '/*']
     end
     
     


### PR DESCRIPTION
The tower_paths method was not returning an array of folders in that directory. Because of this, I could not create a new game. I modified it to work properly. Do not know if it makes a difference, but I tested it on Windows 7.
