### PR TITLE
Adds a version to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ group :test do
   gem 'rake'
   gem 'rspec', '~> 2.8.0'
   gem 'cucumber'
-  gem 'mocha'
+  gem 'mocha', '~> 0.12.0'
 end


### PR DESCRIPTION
Seems that latest mocha (0.13.x) is not compatible with rspec 2.8.x This patch
adds a version for mocha to make the tests work out-of-the-box.

More information can bee seen in the following links:
- https://github.com/rspec/rspec-core/issues/727
- https://github.com/freerange/mocha/issues/107
- http://stackoverflow.com/questions/14588424/cannot-load-such-file-mocha-object-loaderror
