### PR TITLE
Expands path for requiring lib/ruby_warrior

### DIFF
--- a/bin/rubywarrior
+++ b/bin/rubywarrior
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require File.dirname(__FILE__) + '/../lib/ruby_warrior'
+require File.expand_path(File.dirname(__FILE__)) + '/../lib/ruby_warrior'
 
 runner = RubyWarrior::Runner.new(ARGV, STDIN, STDOUT)
 runner.run


### PR DESCRIPTION
This patch allows a simple call to bin/rubywarrior from the project root directory or any other directory.
