### PR TITLE
Fix tests

### DIFF
--- a/spec/ruby_warrior/abilities/listen_spec.rb
+++ b/spec/ruby_warrior/abilities/listen_spec.rb
@@ -12,6 +12,6 @@ describe RubyWarrior::Abilities::Listen do
   
   it "should return an array of spaces which have units on them besides main unit" do
     @floor.add(RubyWarrior::Units::Base.new, 0, 1)
-    @listen.perform.should have(1).record
+    expect(@listen.perform.size).to eq(1)
   end
 end

--- a/spec/ruby_warrior/level_spec.rb
+++ b/spec/ruby_warrior/level_spec.rb
@@ -57,7 +57,7 @@ describe RubyWarrior::Level do
   it "should exist if file exists" do
     @level.stubs(:load_path).returns('/foo/bar')
     File.expects(:exist?).with('/foo/bar').returns(true)
-    @level.exists?.should be_true
+    expect(@level.exists?).to be true
   end
   
   it "should load player and player path" do

--- a/spec/ruby_warrior/ui_spec.rb
+++ b/spec/ruby_warrior/ui_spec.rb
@@ -40,17 +40,17 @@ describe RubyWarrior::UI do
   
   it "should ask for yes/no and return true when yes" do
     @ui.expects(:request).with('foo? [yn] ').returns('y')
-    @ui.ask("foo?").should be_true
+    expect(@ui.ask("foo?")).to be true
   end
   
   it "should ask for yes/no and return false when no" do
     @ui.stubs(:request).returns('n')
-    @ui.ask("foo?").should be_false
+    expect(@ui.ask("foo?")).to be false
   end
   
   it "should ask for yes/no and return false for any input" do
     @ui.stubs(:request).returns('aklhasdf')
-    @ui.ask("foo?").should be_false
+    expect(@ui.ask("foo?")).to be false
   end
   
   it "should present multiple options and return selected one" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,6 @@ RSpec.configure do |config|
     RubyWarrior::Config.reset
   end
   config.expect_with :rspec do |c|
-    c.syntax = [:should]
+    c.syntax = [:should, :expect]
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,4 +7,7 @@ RSpec.configure do |config|
   config.before(:each) do
     RubyWarrior::Config.reset
   end
+  config.expect_with :rspec do |c|
+    c.syntax = [:should]
+  end
 end


### PR DESCRIPTION
Out of the box, five of the tests failed and rspec warned me that the "should" syntax is deprecated. I converted the failing tests to use the "expect" syntax and they passed.
Was this only an issue for me?
Does the inconsistency warrant the rest of the tests to be converted?
