### PR TITLE
Update rspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ tmp/**/*
 *.gem
 .project
 .buildpath
-Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source :rubygems
 
 group :test do
   gem 'rake'
-  gem 'rspec', '~> 2.8.0'
+  gem 'rspec', '~> 3.4.0'
   gem 'cucumber'
   gem 'mocha'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,46 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    builder (3.2.2)
+    cucumber (2.1.0)
+      builder (>= 2.1.2)
+      cucumber-core (~> 1.3.0)
+      diff-lcs (>= 1.1.3)
+      gherkin3 (~> 3.1.0)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.2)
+    cucumber-core (1.3.1)
+      gherkin3 (~> 3.1.0)
+    diff-lcs (1.2.5)
+    gherkin3 (3.1.2)
+    metaclass (0.0.4)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    multi_json (1.11.2)
+    multi_test (0.1.2)
+    rake (10.4.2)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.1)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cucumber
+  mocha
+  rake
+  rspec (~> 3.4.0)
+
+BUNDLED WITH
+   1.11.2

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -11,9 +11,9 @@ When /^I copy fixture "([^\"]*)" to "([^\"]*)"$/ do |from, to|
 end
 
 Then /^I should find file at "([^\"]*)"$/ do |path|
-  File.exist?(path).should be_true
+  expect(File.exist?(path)).to be true
 end
 
 Then /^I should find no file at "([^\"]*)"$/ do |path|
-  File.exist?(path).should be_false
+  expect(File.exist?(path)).to be false
 end

--- a/spec/ruby_warrior/abilities/attack_spec.rb
+++ b/spec/ruby_warrior/abilities/attack_spec.rb
@@ -12,12 +12,12 @@ describe RubyWarrior::Abilities::Attack do
     receiver.health = 5
     @attack.stubs(:unit).returns(receiver)
     @attack.perform
-    receiver.health.should == 2
+    expect(receiver.health).to eq 2
   end
   
   it "should do nothing if recipient is nil" do
     @attack.stubs(:unit).returns(nil)
-    lambda { @attack.perform }.should_not raise_error
+    expect{ @attack.perform }.not_to raise_error
   end
   
   it "should get object at position from offset" do
@@ -46,6 +46,6 @@ describe RubyWarrior::Abilities::Attack do
     receiver.health = 5
     @attack.stubs(:unit).returns(receiver)
     @attack.perform(:backward)
-    receiver.health.should == 3
+    expect(receiver.health).to eq 3
   end
 end

--- a/spec/ruby_warrior/abilities/base_spec.rb
+++ b/spec/ruby_warrior/abilities/base_spec.rb
@@ -7,32 +7,32 @@ describe RubyWarrior::Abilities::Base do
   end
   
   it "should have offset for directions" do
-    @ability.offset(:forward).should == [1, 0]
-    @ability.offset(:right).should == [0, 1]
-    @ability.offset(:backward).should == [-1, 0]
-    @ability.offset(:left).should == [0, -1]
+    expect(@ability.offset(:forward)).to eq [1, 0]
+    expect(@ability.offset(:right)).to eq [0, 1]
+    expect(@ability.offset(:backward)).to eq [-1, 0]
+    expect(@ability.offset(:left)).to eq [0, -1]
   end
   
   it "should have offset for relative forward/right amounts" do
-    @ability.offset(:forward, 2).should == [2, 0]
-    @ability.offset(:forward, 2, 1).should == [2, -1]
-    @ability.offset(:right, 2, 1).should == [1, 2]
-    @ability.offset(:backward, 2, 1).should == [-2, 1]
-    @ability.offset(:left, 2, 1).should == [-1, -2]
+    expect(@ability.offset(:forward, 2)).to eq [2, 0]
+    expect(@ability.offset(:forward, 2, 1)).to eq [2, -1]
+    expect(@ability.offset(:right, 2, 1)).to eq [1, 2]
+    expect(@ability.offset(:backward, 2, 1)).to eq [-2, 1]
+    expect(@ability.offset(:left, 2, 1)).to eq [-1, -2]
   end
   
   it "should fetch unit at given direction with distance" do
     @ability.expects(:space).with(:right, 3, 1).returns(stub(:unit => 'unit'))
-    @ability.unit(:right, 3, 1).should == 'unit'
+    expect(@ability.unit(:right, 3, 1)).to eq 'unit'
   end
   
   it "should have no description" do
-    @ability.description.should be_nil
+    expect(@ability.description).to be_nil
   end
   
   it "should raise an exception if direction isn't recognized" do
-    lambda {
+    expect{
       @ability.verify_direction(:foo)
-    }.should raise_error("Unknown direction :foo. Should be :forward, :backward, :left or :right.")
+    }.to raise_error("Unknown direction :foo. Should be :forward, :backward, :left or :right.")
   end
 end

--- a/spec/ruby_warrior/abilities/bind_spec.rb
+++ b/spec/ruby_warrior/abilities/bind_spec.rb
@@ -9,11 +9,11 @@ describe RubyWarrior::Abilities::Bind do
     receiver = RubyWarrior::Units::Base.new
     @bind.stubs(:unit).returns(receiver)
     @bind.perform
-    receiver.should be_bound
+    expect(receiver).to be_bound
   end
   
   it "should do nothing if no recipient" do
     @bind.stubs(:unit).returns(nil)
-    lambda { @bind.perform }.should_not raise_error
+    expect{ @bind.perform }.not_to raise_error
   end
 end

--- a/spec/ruby_warrior/abilities/direction_of_spec.rb
+++ b/spec/ruby_warrior/abilities/direction_of_spec.rb
@@ -8,6 +8,6 @@ describe RubyWarrior::Abilities::DirectionOf do
   
   it "should return relative direction of given space" do
     @position.stubs(:relative_direction_of).with(:space).returns(:left)
-    @distance.perform(:space).should == :left
+    expect(@distance.perform(:space)).to eq :left
   end
 end

--- a/spec/ruby_warrior/abilities/direction_of_stairs_spec.rb
+++ b/spec/ruby_warrior/abilities/direction_of_stairs_spec.rb
@@ -8,6 +8,6 @@ describe RubyWarrior::Abilities::DirectionOfStairs do
   
   it "should return relative direction of stairs" do
     @position.stubs(:relative_direction_of_stairs).returns(:left)
-    @distance.perform.should == :left
+    expect(@distance.perform).to eq :left
   end
 end

--- a/spec/ruby_warrior/abilities/distance_of_spec.rb
+++ b/spec/ruby_warrior/abilities/distance_of_spec.rb
@@ -8,6 +8,6 @@ describe RubyWarrior::Abilities::DistanceOf do
   
   it "should return distance from stairs" do
     @position.stubs(:distance_of).with(:space).returns(5)
-    @distance.perform(:space).should == 5
+    expect(@distance.perform(:space)).to eq 5
   end
 end

--- a/spec/ruby_warrior/abilities/explode_spec.rb
+++ b/spec/ruby_warrior/abilities/explode_spec.rb
@@ -16,8 +16,8 @@ describe RubyWarrior::Abilities::Explode do
     @floor.add(unit, 0, 1)
     @captive.health = 10
     @explode.perform
-    @captive.health.should == -90
-    unit.health.should == -80
+    expect(@captive.health).to eq -90
+    expect(unit.health).to eq -80
   end
   
   it "should explode when bomb time reaches zero" do
@@ -25,8 +25,8 @@ describe RubyWarrior::Abilities::Explode do
     @explode.time = 3
     @explode.pass_turn
     @explode.pass_turn
-    @captive.health.should == 10
+    expect(@captive.health).to eq 10
     @explode.pass_turn
-    @captive.health.should == -90
+    expect(@captive.health).to eq -90
   end
 end

--- a/spec/ruby_warrior/abilities/form_spec.rb
+++ b/spec/ruby_warrior/abilities/form_spec.rb
@@ -12,37 +12,37 @@ describe RubyWarrior::Abilities::Form do
   
   it "should form a golem in front of warrior" do
     @form.perform
-    @floor.get(1, 0).should be_kind_of(RubyWarrior::Units::Golem)
+    expect(@floor.get(1, 0)).to be_kind_of(RubyWarrior::Units::Golem)
   end
   
   it "should form a golem in given direction" do
     @form.perform(:right)
-    @floor.get(0, 1).should be_kind_of(RubyWarrior::Units::Golem)
+    expect(@floor.get(0, 1)).to be_kind_of(RubyWarrior::Units::Golem)
   end
   
   it "should not form golem if space isn't empty" do
     @floor.add(RubyWarrior::Units::Base.new, 1, 0)
     @form.perform(:forward)
     @form.perform(:left)
-    @floor.units.size.should == 2
+    expect(@floor.units.size).to eq 2
   end
   
   it "should reduce warrior's health by half (rounding down) and give it to the golem" do
     @warrior.health = 19
     @form.perform
-    @warrior.health.should == 10
-    @floor.get(1, 0).max_health.should == 9
+    expect(@warrior.health).to eq 10
+    expect(@floor.get(1, 0).max_health).to eq 9
   end
   
   it "should add passed block as golem's turn block" do
     @passed = nil
     @form.perform(:forward) { |turn| @passed = turn }
     @floor.get(1, 0).play_turn(:turn)
-    @passed.should == :turn
+    expect(@passed).to eq :turn
   end
   
   it "should start in same direction as warrior" do
     @form.perform(:right)
-    @floor.get(0, 1).position.direction.should == :east
+    expect(@floor.get(0, 1).position.direction).to eq :east
   end
 end

--- a/spec/ruby_warrior/abilities/health_spec.rb
+++ b/spec/ruby_warrior/abilities/health_spec.rb
@@ -8,6 +8,6 @@ describe RubyWarrior::Abilities::Health do
   
   it "should return the amount of health" do
     @warrior.health = 10
-    @health.perform.should == 10
+    expect(@health.perform).to eq 10
   end
 end

--- a/spec/ruby_warrior/abilities/listen_spec.rb
+++ b/spec/ruby_warrior/abilities/listen_spec.rb
@@ -12,6 +12,6 @@ describe RubyWarrior::Abilities::Listen do
   
   it "should return an array of spaces which have units on them besides main unit" do
     @floor.add(RubyWarrior::Units::Base.new, 0, 1)
-    @listen.perform.should have(1).record
+    expect(@listen.perform.count).to eq(1)
   end
 end

--- a/spec/ruby_warrior/abilities/look_spec.rb
+++ b/spec/ruby_warrior/abilities/look_spec.rb
@@ -10,6 +10,6 @@ describe RubyWarrior::Abilities::Look do
     @unit.position.expects(:relative_space).with(1, 0).returns(1)
     @unit.position.expects(:relative_space).with(2, 0).returns(2)
     @unit.position.expects(:relative_space).with(3, 0).returns(3)
-    @feel.perform(:forward).should == [1, 2, 3]
+    expect(@feel.perform(:forward)).to eq([1, 2, 3])
   end
 end

--- a/spec/ruby_warrior/abilities/rescue_spec.rb
+++ b/spec/ruby_warrior/abilities/rescue_spec.rb
@@ -13,7 +13,7 @@ describe RubyWarrior::Abilities::Rescue do
     @rescue.expects(:unit).with(:forward).returns(captive)
     @warrior.expects(:earn_points).with(20)
     @rescue.perform
-    captive.position.should be_nil
+    expect(captive.position).to be_nil
   end
   
   it "should do nothing to other unit if not bound" do
@@ -23,7 +23,7 @@ describe RubyWarrior::Abilities::Rescue do
     @rescue.expects(:unit).with(:forward).never
     @warrior.expects(:earn_points).never
     @rescue.perform
-    unit.position.should_not be_nil
+    expect(unit.position).not_to be_nil
   end
   
   it "should release other unit when bound" do
@@ -34,7 +34,7 @@ describe RubyWarrior::Abilities::Rescue do
     @rescue.expects(:unit).with(:forward).returns(unit)
     @warrior.expects(:earn_points).never
     @rescue.perform
-    unit.should_not be_bound
-    unit.position.should_not be_nil
+    expect(unit).not_to be_bound
+    expect(unit.position).not_to be_nil
   end
 end

--- a/spec/ruby_warrior/abilities/rest_spec.rb
+++ b/spec/ruby_warrior/abilities/rest_spec.rb
@@ -10,20 +10,20 @@ describe RubyWarrior::Abilities::Rest do
     @warrior.stubs(:max_health).returns(20)
     @warrior.health = 10
     @rest.perform
-    @warrior.health.should == 12
+    expect(@warrior.health).to eq(12)
   end
   
   it "should add health when at max" do
     @warrior.stubs(:max_health).returns(20)
     @warrior.health = 20
     @rest.perform
-    @warrior.health.should == 20
+    expect(@warrior.health).to eq(20)
   end
   
   it "should not go over max health" do
     @warrior.stubs(:max_health).returns(20)
     @warrior.health = 19
     @rest.perform
-    @warrior.health.should == 20
+    expect(@warrior.health).to eq(20)
   end
 end

--- a/spec/ruby_warrior/abilities/shoot_spec.rb
+++ b/spec/ruby_warrior/abilities/shoot_spec.rb
@@ -17,6 +17,6 @@ describe RubyWarrior::Abilities::Shoot do
   
   it "should shoot and do nothing if no units in the way" do
     @shoot.expects(:multi_unit).with(:forward, anything).returns([nil, nil])
-    lambda { @shoot.perform }.should_not raise_error
+    expect(lambda { @shoot.perform }).not_to raise_error
   end
 end

--- a/spec/ruby_warrior/abilities/throw_spec.rb
+++ b/spec/ruby_warrior/abilities/throw_spec.rb
@@ -18,8 +18,8 @@ describe RubyWarrior::Abilities::Detonate do
     @floor.add(target_unit, 0, 1)
     @floor.add(second_unit, 1, 1)
     @detonate.perform
-    target_unit.health.should == 7
-    second_unit.health.should == 11
+    expect(target_unit.health).to eq(7)
+    expect(second_unit.health).to eq(11)
   end
   
   it "should subtract 8 from left unit and 4 from surrounding units" do
@@ -30,8 +30,8 @@ describe RubyWarrior::Abilities::Detonate do
     @floor.add(target_unit, 1, 0)
     @floor.add(second_unit, 1, 1)
     @detonate.perform(:left)
-    target_unit.health.should == 7
-    second_unit.health.should == 11
+    expect(target_unit.health).to eq(7)
+    expect(second_unit.health).to eq(11)
   end
   
   it "should detonate an explosive if any unit has one" do
@@ -40,7 +40,7 @@ describe RubyWarrior::Abilities::Detonate do
     captive.add_abilities :explode!
     @floor.add(captive, 1, 1)
     @detonate.perform
-    captive.health.should == -99
-    @warrior.health.should == -80
+    expect(captive.health).to eq(-99)
+    expect(@warrior.health).to eq(-80)
   end
 end

--- a/spec/ruby_warrior/abilities/walk_spec.rb
+++ b/spec/ruby_warrior/abilities/walk_spec.rb
@@ -20,6 +20,6 @@ describe RubyWarrior::Abilities::Walk do
   it "should keep position if something is in the way" do
     @position.stubs(:move).raises("shouldn't be called")
     @space.stubs(:empty?).returns(false)
-    lambda { @walk.perform(:right) }.should_not raise_error
+    expect(lambda { @walk.perform(:right) }).not_to raise_error
   end
 end

--- a/spec/ruby_warrior/core_additions_spec.rb
+++ b/spec/ruby_warrior/core_additions_spec.rb
@@ -2,6 +2,6 @@ require 'spec_helper'
 
 describe String do
   it "should wrap text at white space when over a specific character length" do
-    "foo bar blah".hard_wrap(10).should == "foo bar\nblah"
+    expect("foo bar blah".hard_wrap(10)).to eq("foo bar\nblah")
   end
 end

--- a/spec/ruby_warrior/floor_spec.rb
+++ b/spec/ruby_warrior/floor_spec.rb
@@ -11,14 +11,14 @@ describe RubyWarrior::Floor do
     it "should be able to add a unit and fetch it at that position" do
       unit = RubyWarrior::Units::Base.new
       @floor.add(unit, 0, 1, :north)
-      @floor.get(0, 1).should == unit
+      expect(@floor.get(0, 1)).to eq(unit)
     end
   
     it "should not consider unit on floor if no position" do
       unit = RubyWarrior::Units::Base.new
       @floor.add(unit, 0, 1, :north)
       unit.position = nil
-      @floor.units.should_not include(unit)
+      expect(@floor.units).not_to include(unit)
     end
   
     it "should fetch other units not warrior" do
@@ -26,31 +26,31 @@ describe RubyWarrior::Floor do
       warrior = RubyWarrior::Units::Warrior.new
       @floor.add(unit, 0, 0, :north)
       @floor.add(warrior, 1, 0, :north)
-      @floor.other_units.should_not include(warrior)
-      @floor.other_units.should include(unit)
+      expect(@floor.other_units).not_to include(warrior)
+      expect(@floor.other_units).to include(unit)
     end
   
     it "should not consider corners out of bounds" do
-      @floor.should_not be_out_of_bounds(0, 0)
-      @floor.should_not be_out_of_bounds(1, 0)
-      @floor.should_not be_out_of_bounds(1, 2)
-      @floor.should_not be_out_of_bounds(0, 2)
+      expect(@floor).not_to be_out_of_bounds(0, 0)
+      expect(@floor).not_to be_out_of_bounds(1, 0)
+      expect(@floor).not_to be_out_of_bounds(1, 2)
+      expect(@floor).not_to be_out_of_bounds(0, 2)
     end
   
     it "should consider out of bounds when going beyond sides" do
-      @floor.should be_out_of_bounds(-1, 0)
-      @floor.should be_out_of_bounds(0, -1)
-      @floor.should be_out_of_bounds(0, 3)
-      @floor.should be_out_of_bounds(2, 0)
+      expect(@floor).to be_out_of_bounds(-1, 0)
+      expect(@floor).to be_out_of_bounds(0, -1)
+      expect(@floor).to be_out_of_bounds(0, 3)
+      expect(@floor).to be_out_of_bounds(2, 0)
     end
   
     it "should return space at the specified location" do
-      @floor.space(0, 0).should be_kind_of(RubyWarrior::Space)
+      expect(@floor.space(0, 0)).to be_kind_of(RubyWarrior::Space)
     end
   
     it "should place stairs and be able to fetch the location" do
       @floor.place_stairs(1, 2)
-      @floor.stairs_location.should == [1, 2]
+      expect(@floor.stairs_location).to eq([1, 2])
     end
   end
   
@@ -64,7 +64,7 @@ describe RubyWarrior::Floor do
     it "should print map with stairs and unit" do
       @floor.add(RubyWarrior::Units::Warrior.new, 0, 0)
       @floor.place_stairs(2, 0)
-      @floor.character.should == <<-MAP
+      expect(@floor.character).to eq(<<-MAP)
  ---
 |@ >|
  ---
@@ -75,7 +75,7 @@ MAP
       u1 = RubyWarrior::Units::Base.new
       @floor.add(u1, 0, 0)
       @floor.add(RubyWarrior::Units::Base.new, 1, 0)
-      @floor.unique_units.should == [u1]
+      expect(@floor.unique_units).to eq([u1])
     end
   end
 end

--- a/spec/ruby_warrior/game_spec.rb
+++ b/spec/ruby_warrior/game_spec.rb
@@ -16,7 +16,7 @@ describe RubyWarrior::Game do
   it "should not make game and exit if player says no" do
     RubyWarrior::UI.stubs(:ask).returns(false)
     Dir.stubs(:mkdir).raises('should not be called')
-    lambda { @game.make_game_directory }.should raise_error(SystemExit)
+    expect{ @game.make_game_directory }.to raise_error(SystemExit)
   end
   
   
@@ -26,7 +26,7 @@ describe RubyWarrior::Game do
     RubyWarrior::Profile.expects(:load).with('foo/.profile').returns(1)
     RubyWarrior::Profile.expects(:load).with('bar/.profile').returns(2)
     @game.stubs(:profile_paths).returns(['foo/.profile', 'bar/.profile'])
-    @game.profiles.should == [1, 2]
+    expect(@game.profiles).to eq([1, 2])
   end
   
   it "should find profile paths using Dir[] search" do
@@ -37,13 +37,13 @@ describe RubyWarrior::Game do
   it "should try to create profile when no profile paths are specified" do
     @game.stubs(:profiles).returns([])
     @game.expects(:new_profile).returns('profile')
-    @game.profile.should == 'profile'
+    expect(@game.profile).to eq('profile')
   end
   
   it "should ask a player to choose a profile if multiple profiles are available, but only once" do
     RubyWarrior::UI.expects(:choose).with('profile', [:profile1, [:new, 'New Profile']]).returns(:profile1)
     @game.stubs(:profiles).returns([:profile1])
-    2.times { @game.profile.should == :profile1 }
+    2.times { expect(@game.profile).to eq(:profile1) }
   end
   
   it "should ask user to choose a tower when creating a new profile" do
@@ -60,7 +60,7 @@ describe RubyWarrior::Game do
     RubyWarrior::Profile.expects(:new).returns(profile)
     profile.expects(:tower_path=).with('tower_path')
     profile.expects(:warrior_name=).with('name')
-    @game.new_profile.should == profile
+    expect(@game.new_profile).to eq(profile)
   end
   
   
@@ -70,7 +70,7 @@ describe RubyWarrior::Game do
     RubyWarrior::Tower.expects(:new).with('towers/foo').returns(1)
     RubyWarrior::Tower.expects(:new).with('towers/bar').returns(2)
     @game.stubs(:tower_paths).returns(['towers/foo', 'towers/bar'])
-    @game.towers.should == [1, 2]
+    expect(@game.towers).to eq([1, 2])
   end
   
   it "should find tower paths using Dir[] search" do
@@ -84,13 +84,13 @@ describe RubyWarrior::Game do
   it "should fetch current level from profile and cache it" do
     @game.stubs(:profile).returns(stub)
     @game.profile.expects(:current_level).returns('foo')
-    2.times { @game.current_level.should == 'foo' }
+    2.times { expect(@game.current_level).to eq('foo') }
   end
   
   it "should fetch next level from profile and cache it" do
     @game.stubs(:profile).returns(stub)
     @game.profile.expects(:next_level).returns('bar')
-    2.times { @game.next_level.should == 'bar' }
+    2.times { expect(@game.next_level).to eq('bar') }
   end
   
   it "should report final grade" do
@@ -98,15 +98,15 @@ describe RubyWarrior::Game do
     profile.current_epic_grades = { 1 => 0.7, 2 => 0.9 }
     @game.stubs(:profile).returns(profile)
     report = @game.final_report
-    report.should include("Your average grade for this tower is: B")
-    report.should include("Level 1: C\n  Level 2: A")
+    expect(report).to include("Your average grade for this tower is: B")
+    expect(report).to include("Level 1: C\n  Level 2: A")
   end
   
   it "should have an empty final report if no epic grades are available" do
     profile = RubyWarrior::Profile.new
     profile.current_epic_grades = {}
     @game.stubs(:profile).returns(profile)
-    @game.final_report.should be_nil
+    expect(@game.final_report).to be_nil
   end
   
   it "should have an empty final report if practice level" do
@@ -114,6 +114,6 @@ describe RubyWarrior::Game do
     profile = RubyWarrior::Profile.new
     profile.current_epic_grades = { 1 => 0.7, 2 => 0.9 }
     @game.stubs(:profile).returns(profile)
-    @game.final_report.should be_nil
+    expect(@game.final_report).to be_nil
   end
 end

--- a/spec/ruby_warrior/level_loader_spec.rb
+++ b/spec/ruby_warrior/level_loader_spec.rb
@@ -12,15 +12,15 @@ describe RubyWarrior::LevelLoader do
       @loader.description "foo"
       @loader.tip "bar"
       @loader.clue "clue"
-      @level.description.should == "foo"
-      @level.tip.should == "bar"
-      @level.clue.should == "clue"
+      expect(@level.description).to eq("foo")
+      expect(@level.tip).to eq("bar")
+      expect(@level.clue).to eq("clue")
     end
     
     it "should be able to set size" do
       @loader.size 5, 3
-      @level.floor.width.should == 5
-      @level.floor.height.should == 3
+      expect(@level.floor.width).to eq(5)
+      expect(@level.floor.height).to eq(3)
     end
     
     it "should be able to add stairs" do
@@ -30,25 +30,25 @@ describe RubyWarrior::LevelLoader do
     
     it "should yield new unit when building" do
       @loader.unit :base, 1, 2 do |unit|
-        unit.should be_kind_of(RubyWarrior::Units::Base)
-        unit.position.should be_at(1, 2)
+        expect(unit).to be_kind_of(RubyWarrior::Units::Base)
+        expect(unit.position).to be_at(1, 2)
       end
     end
     
     it "should be able to add multi-word units" do
-      lambda { @loader.unit :thick_sludge, 1, 2 }.should_not raise_error
+      expect(lambda { @loader.unit :thick_sludge, 1, 2 }).not_to raise_error
     end
     
     it "should build warrior from profile" do
       @loader.warrior 1, 2 do |unit|
-        unit.should be_kind_of(RubyWarrior::Units::Warrior)
-        unit.position.should be_at(1, 2)
+        expect(unit).to be_kind_of(RubyWarrior::Units::Warrior)
+        expect(unit.position).to be_at(1, 2)
       end
     end
     
     it "should be able to set time bonus" do
       @loader.time_bonus 100
-      @level.time_bonus.should == 100
+      expect(@level.time_bonus).to eq(100)
     end
   end
 end

--- a/spec/ruby_warrior/level_spec.rb
+++ b/spec/ruby_warrior/level_spec.rb
@@ -14,44 +14,44 @@ describe RubyWarrior::Level do
     @level.warrior = RubyWarrior::Units::Warrior.new
     @floor.add(@level.warrior, 0, 0, :north)
     @floor.place_stairs(0, 0)
-    @level.should be_passed
+    expect(@level).to be_passed
   end
   
   it "should default time bonus to zero" do
-    @level.time_bonus.should be_zero
+    expect(@level.time_bonus).to be_zero
   end
   
   it "should have a grade relative to ace score" do
     @level.ace_score = 100
-    @level.grade_for(110).should == "S"
-    @level.grade_for(100).should == "S"
-    @level.grade_for(99).should == "A"
-    @level.grade_for(89).should == "B"
-    @level.grade_for(79).should == "C"
-    @level.grade_for(69).should == "D"
-    @level.grade_for(59).should == "F"
+    expect(@level.grade_for(110)).to eq("S")
+    expect(@level.grade_for(100)).to eq("S")
+    expect(@level.grade_for(99)).to eq("A")
+    expect(@level.grade_for(89)).to eq("B")
+    expect(@level.grade_for(79)).to eq("C")
+    expect(@level.grade_for(69)).to eq("D")
+    expect(@level.grade_for(59)).to eq("F")
   end
   
   it "should have no grade if there is no ace score" do
-    @level.ace_score.should be_nil
-    @level.grade_for(100).should be_nil
+    expect(@level.ace_score).to be_nil
+    expect(@level.grade_for(100)).to be_nil
   end
   
   it "should load file contents into level" do
     @level.stubs(:load_path).returns('path/to/level.rb')
     File.expects(:read).with('path/to/level.rb').returns("description 'foo'")
     @level.load_level
-    @level.description.should == 'foo'
+    expect(@level.description).to eq('foo')
   end
   
   it "should have a player path from profile" do
     @profile.stubs(:player_path).returns('path/to/player')
-    @level.player_path.should == 'path/to/player'
+    expect(@level.player_path).to eq('path/to/player')
   end
   
   it "should have a load path from profile tower with level number in it" do
     @profile.stubs(:tower_path).returns('path/to/tower')
-    @level.load_path.should == File.expand_path('towers/tower/level_001.rb')
+    expect(@level.load_path).to eq(File.expand_path('towers/tower/level_001.rb'))
   end
   
   it "should exist if file exists" do
@@ -120,27 +120,27 @@ describe RubyWarrior::Level do
       @level.play(2) do
         int += 1
       end
-      int.should == 2
+      expect(int).to eq(2)
     end
   
     it "should count down time_bonus once each turn" do
       @level.time_bonus = 10
       @level.play(3)
-      @level.time_bonus.should == 7
+      expect(@level.time_bonus).to eq(7)
     end
   
     it "should count down time_bonus below 0" do
       @level.time_bonus = 2
       @level.play(5)
-      @level.time_bonus.should be_zero
+      expect(@level.time_bonus).to be_zero
     end
     
     it "should have a pretty score calculation" do
-      @level.score_calculation(123, 45).should == "123 + 45 = 168"
+      expect(@level.score_calculation(123, 45)).to eq("123 + 45 = 168")
     end
     
     it "should not have a score calculation when starting score is zero" do
-      @level.score_calculation(0, 45).should == "45"
+      expect(@level.score_calculation(0, 45)).to eq("45")
     end
   end
   
@@ -154,14 +154,14 @@ describe RubyWarrior::Level do
     it "should add warrior score to profile" do
       @warrior.stubs(:score).returns(30)
       @level.tally_points
-      @profile.score.should == 30
+      expect(@profile.score).to eq(30)
     end
     
     it "should add warrior score to profile for epic mode" do
       @profile.enable_epic_mode
       @warrior.stubs(:score).returns(30)
       @level.tally_points
-      @profile.current_epic_score.should == 30
+      expect(@profile.current_epic_score).to eq(30)
     end
     
     it "should add level grade percent to profile for epic mode" do
@@ -169,7 +169,7 @@ describe RubyWarrior::Level do
       @profile.enable_epic_mode
       @warrior.stubs(:score).returns(30)
       @level.tally_points
-      @profile.current_epic_grades.should == { 1 => 0.3 }
+      expect(@profile.current_epic_grades).to eq({ 1 => 0.3 })
     end
     
     it "should not add level grade if ace score is not set" do
@@ -177,19 +177,19 @@ describe RubyWarrior::Level do
       @profile.enable_epic_mode
       @warrior.stubs(:score).returns(30)
       @level.tally_points
-      @profile.current_epic_grades.should == {}
+      expect(@profile.current_epic_grades).to eq({})
     end
     
     it "should apply warrior abilities to profile" do
       @warrior.stubs(:abilities).returns({:foo => nil, :bar => nil})
       @level.tally_points
-      @profile.abilities.to_set.should == [:foo, :bar].to_set
+      expect(@profile.abilities.to_set).to eq([:foo, :bar].to_set)
     end
     
     it "should apply time bonus to profile score" do
       @level.time_bonus = 20
       @level.tally_points
-      @profile.score.should == 20
+      expect(@profile.score).to eq(20)
     end
     
     it "should give 20% bonus when no other units left" do
@@ -197,7 +197,7 @@ describe RubyWarrior::Level do
       @warrior.stubs(:score).returns(10)
       @level.time_bonus = 10
       @level.tally_points
-      @profile.score.should == 24
+      expect(@profile.score).to eq(24)
     end
   end
 end

--- a/spec/ruby_warrior/level_spec.rb
+++ b/spec/ruby_warrior/level_spec.rb
@@ -57,7 +57,7 @@ describe RubyWarrior::Level do
   it "should exist if file exists" do
     @level.stubs(:load_path).returns('/foo/bar')
     File.expects(:exist?).with('/foo/bar').returns(true)
-    @level.exists?.should be_true
+    expect(@level.exists?).to eq true
   end
   
   it "should load player and player path" do

--- a/spec/ruby_warrior/player_generator_spec.rb
+++ b/spec/ruby_warrior/player_generator_spec.rb
@@ -7,6 +7,6 @@ describe RubyWarrior::PlayerGenerator do
   end
   
   it "should know templates path" do
-    @generator.templates_path.should == File.expand_path("../../../templates", __FILE__)
+    expect(@generator.templates_path).to eq(File.expand_path("../../../templates", __FILE__))
   end
 end

--- a/spec/ruby_warrior/position_spec.rb
+++ b/spec/ruby_warrior/position_spec.rb
@@ -11,98 +11,98 @@ describe RubyWarrior::Position do
   end
   
   it "should rotate clockwise" do
-    @position.direction.should == :north
+    expect(@position.direction).to eq(:north)
     [:east, :south, :west, :north, :east].each do |dir|
       @position.rotate(1)
-      @position.direction.should == dir
+      expect(@position.direction).to eq(dir)
     end
   end
   
   it "should rotate counterclockwise" do
-    @position.direction.should == :north
+    expect(@position.direction).to eq(:north)
     [:west, :south, :east, :north, :west].each do |dir|
       @position.rotate(-1)
-      @position.direction.should == dir
+      expect(@position.direction).to eq(dir)
     end
   end
   
   it "should get relative space in front" do
     unit = RubyWarrior::Units::Base.new
     @floor.add(unit, 1, 1)
-    @position.relative_space(1).should_not be_empty
+    expect(@position.relative_space(1)).not_to be_empty
   end
   
   it "should get relative object in front when rotated" do
     unit = RubyWarrior::Units::Base.new
     @floor.add(unit, 2, 2)
     @position.rotate(1)
-    @position.relative_space(1).should_not be_empty
+    expect(@position.relative_space(1)).not_to be_empty
   end
   
   it "should get relative object diagonally" do
     unit = RubyWarrior::Units::Base.new
     @floor.add(unit, 0, 1)
-    @position.relative_space(1, -1).should_not be_empty
+    expect(@position.relative_space(1, -1)).not_to be_empty
   end
   
   it "should get relative object diagonally when rotating" do
     unit = RubyWarrior::Units::Base.new
     @floor.add(unit, 0, 1)
     @position.rotate(2)
-    @position.relative_space(-1, 1).should_not be_empty
+    expect(@position.relative_space(-1, 1)).not_to be_empty
   end
   
   it "should move object on floor relatively" do
-    @floor.get(1, 2).should == @unit
+    expect(@floor.get(1, 2)).to eq(@unit)
     @position.move(-1, 2)
-    @floor.get(1, 2).should be_nil
-    @floor.get(3, 3).should == @unit
+    expect(@floor.get(1, 2)).to be_nil
+    expect(@floor.get(3, 3)).to eq(@unit)
     @position.rotate(1)
     @position.move(-1)
-    @floor.get(3, 3).should be_nil
-    @floor.get(2, 3).should == @unit
+    expect(@floor.get(3, 3)).to be_nil
+    expect(@floor.get(2, 3)).to eq(@unit)
   end
   
   it "should return distance from stairs as 0 when on stairs" do
     @floor.place_stairs(1, 2)
-    @position.distance_from_stairs.should == 0
+    expect(@position.distance_from_stairs).to eq(0)
   end
   
   it "should return distance from stairs in both directions" do
     @floor.place_stairs(0, 3)
-    @position.distance_from_stairs.should == 2
+    expect(@position.distance_from_stairs).to eq(2)
   end
   
   it "should return relative direction of stairs" do
     @floor.place_stairs(0, 0)
-    @position.relative_direction_of_stairs.should == :forward
+    expect(@position.relative_direction_of_stairs).to eq(:forward)
   end
   
   it "should return relative direction of given space" do
-    @position.relative_direction_of(@floor.space(5, 3)).should == :right
+    expect(@position.relative_direction_of(@floor.space(5, 3))).to eq(:right)
     @position.rotate 1
-    @position.relative_direction_of(@floor.space(1, 4)).should == :right
+    expect(@position.relative_direction_of(@floor.space(1, 4))).to eq(:right)
   end
   
   it "should be able to determine relative direction" do
-    @position.relative_direction(:north).should == :forward
-    @position.relative_direction(:south).should == :backward
-    @position.relative_direction(:west).should == :left
-    @position.relative_direction(:east).should == :right
+    expect(@position.relative_direction(:north)).to eq(:forward)
+    expect(@position.relative_direction(:south)).to eq(:backward)
+    expect(@position.relative_direction(:west)).to eq(:left)
+    expect(@position.relative_direction(:east)).to eq(:right)
     @position.rotate 1
-    @position.relative_direction(:north).should == :left
+    expect(@position.relative_direction(:north)).to eq(:left)
     @position.rotate 1
-    @position.relative_direction(:north).should == :backward
+    expect(@position.relative_direction(:north)).to eq(:backward)
     @position.rotate 1
-    @position.relative_direction(:north).should == :right
+    expect(@position.relative_direction(:north)).to eq(:right)
   end
   
   it "should return a space at the same location as position" do
-    @position.space.location.should == [1, 2]
+    expect(@position.space.location).to eq([1, 2])
   end
   
   it "should return distance of given space" do
-    @position.distance_of(@floor.space(5, 3)).should == 5
-    @position.distance_of(@floor.space(4, 2)).should == 3
+    expect(@position.distance_of(@floor.space(5, 3))).to eq(5)
+    expect(@position.distance_of(@floor.space(4, 2))).to eq(3)
   end
 end

--- a/spec/ruby_warrior/profile_spec.rb
+++ b/spec/ruby_warrior/profile_spec.rb
@@ -7,31 +7,31 @@ describe RubyWarrior::Profile do
   
   it "should have warrior name" do
     @profile.warrior_name = 'Joe'
-    @profile.warrior_name.should == 'Joe'
+    expect(@profile.warrior_name).to eq('Joe')
   end
   
   it "should start level number at 0" do
-    @profile.level_number.should be_zero
+    expect(@profile.level_number).to be_zero
   end
   
   it "should start score at 0 and allow it to increment" do
-    @profile.score.should be_zero
+    expect(@profile.score).to be_zero
     @profile.score += 5
-    @profile.score.should == 5
+    expect(@profile.score).to eq(5)
   end
   
   it "should have no abilities and allow adding" do
-    @profile.abilities.should == []
+    expect(@profile.abilities).to eq([])
     @profile.abilities += [:foo, :bar]
-    @profile.abilities.should == [:foo, :bar]
+    expect(@profile.abilities).to eq([:foo, :bar])
   end
   
   it "should encode with marshal + base64" do
-    @profile.encode.should == Base64.encode64(Marshal.dump(@profile))
+    expect(@profile.encode).to eq(Base64.encode64(Marshal.dump(@profile)))
   end
   
   it "should decode with marshal + base64" do
-    RubyWarrior::Profile.decode(@profile.encode).warrior_name.should == @profile.warrior_name
+    expect(RubyWarrior::Profile.decode(@profile.encode).warrior_name).to eq(@profile.warrior_name)
   end
   
   it "load should read file, decode and set player path" do
@@ -39,43 +39,43 @@ describe RubyWarrior::Profile do
     profile.expects(:player_path=).with('path/to')
     File.expects(:read).with('path/to/.profile').returns('encoded_profile')
     RubyWarrior::Profile.expects(:decode).with('encoded_profile').returns(profile)
-    RubyWarrior::Profile.load('path/to/.profile').should == profile
+    expect(RubyWarrior::Profile.load('path/to/.profile')).to eq(profile)
   end
 
   
   it "should add abilities and remove duplicates" do
     @profile.add_abilities(:foo, :bar, :blah, :bar)
-    @profile.abilities.should == [:foo, :bar, :blah]
+    expect(@profile.abilities).to eq([:foo, :bar, :blah])
   end
     
   it "should fetch new level with current number" do
     @profile.level_number = 1
-    @profile.current_level.number.should == 1
+    expect(@profile.current_level.number).to eq(1)
   end
 
   it "should fetch next level" do
     @profile.level_number = 1
-    @profile.next_level.number.should == 2
+    expect(@profile.next_level.number).to eq(2)
   end
 
   it "should enable epic mode and reset scores if nil" do
     @profile.epic_score = nil
     @profile.current_epic_score = nil
     @profile.enable_epic_mode
-    @profile.should be_epic
-    @profile.epic_score.should be_zero
-    @profile.current_epic_score.should be_zero
+    expect(@profile).to be_epic
+    expect(@profile.epic_score).to be_zero
+    expect(@profile.current_epic_score).to be_zero
   end
   
   it "should override epic score with current one if it is higher" do
     @profile.enable_epic_mode
-    @profile.epic_score.should be_zero
-    @profile.average_grade.should be_nil
+    expect(@profile.epic_score).to be_zero
+    expect(@profile.average_grade).to be_nil
     @profile.current_epic_score = 123
     @profile.current_epic_grades = { 1 => 0.7, 2 => 0.9 }
     @profile.update_epic_score
-    @profile.epic_score.should == 123
-    @profile.average_grade.should == 0.8
+    expect(@profile.epic_score).to eq(123)
+    expect(@profile.average_grade).to eq(0.8)
   end
   
   it "should not override epic score with current one if it is lower" do
@@ -85,20 +85,20 @@ describe RubyWarrior::Profile do
     @profile.current_epic_score = 123
     @profile.current_epic_grades = { 1 => 0.7, 2 => 0.9 }
     @profile.update_epic_score
-    @profile.epic_score.should == 124
-    @profile.average_grade.should == 0.9
+    expect(@profile.epic_score).to eq(124)
+    expect(@profile.average_grade).to eq(0.9)
   end
   
   it "should not calculate average grade if no grades are present" do
     @profile.enable_epic_mode
     @profile.current_epic_grades = {}
-    @profile.calculate_average_grade.should be_nil
+    expect(@profile.calculate_average_grade).to be_nil
   end
 
   it "should remember current level number as last_level_number" do
     @profile.level_number = 7
     @profile.enable_epic_mode
-    @profile.last_level_number.should == 7
+    expect(@profile.last_level_number).to eq(7)
   end
 
   it "should enable normal mode by clearing epic scores and resetting last level number" do
@@ -108,18 +108,18 @@ describe RubyWarrior::Profile do
     @profile.current_epic_grades = { 1 => 100 }
     @profile.average_grade = "C"
     @profile.enable_normal_mode
-    @profile.should_not be_epic
-    @profile.epic_score.should be_zero
-    @profile.current_epic_score.should be_zero
-    @profile.last_level_number.should be_nil
-    @profile.average_grade.should be_nil
-    @profile.current_epic_grades.should == {}
-    @profile.level_number.should == 7
+    expect(@profile).not_to be_epic
+    expect(@profile.epic_score).to be_zero
+    expect(@profile.current_epic_score).to be_zero
+    expect(@profile.last_level_number).to be_nil
+    expect(@profile.average_grade).to be_nil
+    expect(@profile.current_epic_grades).to eq({})
+    expect(@profile.level_number).to eq(7)
   end
 
   it "should be no level after epic if last level isn't specified" do
     @profile.last_level_number = nil
-    @profile.should_not be_level_after_epic
+    expect(@profile).not_to be_level_after_epic
   end
   
   describe "with tower path" do
@@ -138,34 +138,34 @@ describe RubyWarrior::Profile do
     
     it "should have a nice string representation" do
       @profile.warrior_name = 'Joe'
-      @profile.to_s.should == "Joe - tower - level 0 - score 0"
+      expect(@profile.to_s).to eq("Joe - tower - level 0 - score 0")
     end
     
     it "should include epic score in string representation" do
       @profile.warrior_name = 'Joe'
       @profile.enable_epic_mode
-      @profile.to_s.should == "Joe - tower - first score 0 - epic score 0"
+      expect(@profile.to_s).to eq("Joe - tower - first score 0 - epic score 0")
     end
     
     it "should include epic score with grade in string representation" do
       @profile.warrior_name = 'Joe'
       @profile.enable_epic_mode
       @profile.average_grade = 0.7
-      @profile.to_s.should == "Joe - tower - first score 0 - epic score 0 (C)"
+      expect(@profile.to_s).to eq("Joe - tower - first score 0 - epic score 0 (C)")
     end
     
     it "should guess at the player path" do
-      @profile.player_path.should == './rubywarrior/john-smith-tower'
+      expect(@profile.player_path).to eq('./rubywarrior/john-smith-tower')
     end
   
     it "should use specified player path" do
       @profile.player_path = "path/to/player"
-      @profile.player_path.should == "path/to/player"
+      expect(@profile.player_path).to eq("path/to/player")
     end
   
     it "should load tower from path" do
       RubyWarrior::Tower.expects(:new).with('tower').returns('tower')
-      @profile.tower.should == 'tower'
+      expect(@profile.tower).to eq('tower')
     end
   end
 end

--- a/spec/ruby_warrior/space_spec.rb
+++ b/spec/ruby_warrior/space_spec.rb
@@ -13,35 +13,35 @@ describe RubyWarrior::Space do
     end
     
     it "should not be enemy" do
-      @space.should_not be_enemy
+      expect(@space).not_to be_enemy
     end
     
     it "should not be warrior" do
-      @space.should_not be_warrior
+      expect(@space).not_to be_warrior
     end
     
     it "should be empty" do
-      @space.should be_empty
+      expect(@space).to be_empty
     end
     
     it "should not be wall" do
-      @space.should_not be_wall
+      expect(@space).not_to be_wall
     end
     
     it "should not be stairs" do
-      @space.should_not be_stairs
+      expect(@space).not_to be_stairs
     end
     
     it "should not be captive" do
-      @space.should_not be_captive
+      expect(@space).not_to be_captive
     end
     
     it "should say 'nothing' as name" do
-      @space.to_s.should == 'nothing'
+      expect(@space.to_s).to eq('nothing')
     end
     
     it "should not be ticking" do
-      @space.should_not be_ticking
+      expect(@space).not_to be_ticking
     end
   end
   
@@ -51,15 +51,15 @@ describe RubyWarrior::Space do
     end
   
     it "should be wall" do
-      @space.should be_wall
+      expect(@space).to be_wall
     end
   
     it "should not be empty" do
-      @space.should_not be_empty
+      expect(@space).not_to be_empty
     end
     
     it "should have name of 'wall'" do
-      @space.to_s.should == 'wall'
+      expect(@space.to_s).to eq('wall')
     end
   end
   
@@ -71,23 +71,23 @@ describe RubyWarrior::Space do
     end
     
     it "should be warrior" do
-      @space.should be_warrior
+      expect(@space).to be_warrior
     end
     
     it "should be player" do
-      @space.should be_warrior
+      expect(@space).to be_warrior
     end
     
     it "should not be enemy" do
-      @space.should_not be_enemy
+      expect(@space).not_to be_enemy
     end
     
     it "should not be empty" do
-      @space.should_not be_enemy
+      expect(@space).not_to be_enemy
     end
     
     it "should know what unit is on that space" do
-      @space.unit.should be_kind_of(RubyWarrior::Units::Warrior)
+      expect(@space.unit).to be_kind_of(RubyWarrior::Units::Warrior)
     end
   end
   
@@ -98,19 +98,19 @@ describe RubyWarrior::Space do
     end
     
     it "should be enemy" do
-      @space.should be_enemy
+      expect(@space).to be_enemy
     end
     
     it "should not be warrior" do
-      @space.should_not be_warrior
+      expect(@space).not_to be_warrior
     end
     
     it "should not be empty" do
-      @space.should_not be_empty
+      expect(@space).not_to be_empty
     end
     
     it "should have name of unit" do
-      @space.to_s.should == "Sludge"
+      expect(@space.to_s).to eq("Sludge")
     end
     
     describe "bound" do
@@ -119,11 +119,11 @@ describe RubyWarrior::Space do
       end
       
       it "should be captive" do
-        @space.should be_captive
+        expect(@space).to be_captive
       end
       
       it "should not look like enemy" do
-        @space.should_not be_enemy
+        expect(@space).not_to be_enemy
       end
     end
   end
@@ -136,20 +136,20 @@ describe RubyWarrior::Space do
     end
     
     it "should be captive" do
-      @space.should be_captive
+      expect(@space).to be_captive
     end
     
     it "should not be enemy" do
-      @space.should_not be_enemy
+      expect(@space).not_to be_enemy
     end
     
     it "should be ticking if captive has time bomb" do
       @captive.add_abilities :explode!
-      @space.should be_ticking
+      expect(@space).to be_ticking
     end
     
     it "should not be ticking if captive does not have time bomb" do
-      @space.should_not be_ticking
+      expect(@space).not_to be_ticking
     end
   end
   
@@ -161,15 +161,15 @@ describe RubyWarrior::Space do
     end
     
     it "should be golem" do
-      @space.should be_golem
+      expect(@space).to be_golem
     end
     
     it "should not be enemy" do
-      @space.should_not be_enemy
+      expect(@space).not_to be_enemy
     end
     
     it "should be player" do
-      @space.should be_player
+      expect(@space).to be_player
     end
   end
   
@@ -180,11 +180,11 @@ describe RubyWarrior::Space do
     end
     
     it "should be empty" do
-      @space.should be_empty
+      expect(@space).to be_empty
     end
     
     it "should be stairs" do
-      @space.should be_stairs
+      expect(@space).to be_stairs
     end
   end
 end

--- a/spec/ruby_warrior/tower_spec.rb
+++ b/spec/ruby_warrior/tower_spec.rb
@@ -6,10 +6,10 @@ describe RubyWarrior::Tower do
   end
   
   it "should consider last part of path as name" do
-    @tower.name.should == 'tower'
+    expect(@tower.name).to eq('tower')
   end
   
   it "should use name when converting to string" do
-    @tower.to_s.should == @tower.name
+    expect(@tower.to_s).to eq(@tower.name)
   end
 end

--- a/spec/ruby_warrior/turn_spec.rb
+++ b/spec/ruby_warrior/turn_spec.rb
@@ -7,22 +7,22 @@ describe RubyWarrior::Turn do
     end
     
     it "should have no action performed at first" do
-      @turn.action.should be_nil
+      expect(@turn.action).to be_nil
     end
     
     it "should be able to perform action and recall it" do
       @turn.walk!
-      @turn.action.should == [:walk!]
+      expect(@turn.action).to eq([:walk!])
     end
     
     it "should include arguments passed to action" do
       @turn.walk! :forward
-      @turn.action.should == [:walk!, :forward]
+      expect(@turn.action).to eq([:walk!, :forward])
     end
     
     it "should not be able to call multiple actions per turn" do
       @turn.walk! :forward
-      lambda { @turn.attack! }.should raise_error
+      expect(lambda { @turn.attack! }).to raise_error "Only one action can be performed per turn."
     end
   end
   
@@ -35,8 +35,8 @@ describe RubyWarrior::Turn do
     end
     
     it "should be able to call sense with any argument and return expected results" do
-      @turn.feel.should == @feel.perform
-      @turn.feel(:backward).should == @feel.perform(:backward)
+      expect(@turn.feel).to eq(@feel.perform)
+      expect(@turn.feel(:backward)).to eq(@feel.perform(:backward))
     end
   end
 end

--- a/spec/ruby_warrior/ui_spec.rb
+++ b/spec/ruby_warrior/ui_spec.rb
@@ -40,17 +40,17 @@ describe RubyWarrior::UI do
   
   it "should ask for yes/no and return true when yes" do
     @ui.expects(:request).with('foo? [yn] ').returns('y')
-    @ui.ask("foo?").should be_true
+    expect(@ui.ask("foo?")).to eq true
   end
   
   it "should ask for yes/no and return false when no" do
     @ui.stubs(:request).returns('n')
-    @ui.ask("foo?").should be_false
+    expect(@ui.ask("foo?")).to eq false
   end
   
   it "should ask for yes/no and return false for any input" do
     @ui.stubs(:request).returns('aklhasdf')
-    @ui.ask("foo?").should be_false
+    expect(@ui.ask("foo?")).to eq false
   end
   
   it "should present multiple options and return selected one" do

--- a/spec/ruby_warrior/ui_spec.rb
+++ b/spec/ruby_warrior/ui_spec.rb
@@ -12,30 +12,30 @@ describe RubyWarrior::UI do
   
   it "should add puts to out stream" do
     @ui.puts "hello"
-    @out.string.should == "hello\n"
+    expect(@out.string).to eq("hello\n")
   end
   
   it "should add print to out stream without newline" do
     @ui.print "hello"
-    @out.string.should == "hello"
+    expect(@out.string).to eq("hello")
   end
   
   it "should fetch gets from in stream" do
     @in.puts "bar"
     @in.rewind
-    @ui.gets.should == "bar\n"
+    expect(@ui.gets).to eq("bar\n")
   end
   
   it "should gets should return empty string if no input" do
     @config.in_stream = nil
-    @ui.gets.should == ""
+    expect(@ui.gets).to eq("")
   end
   
   it "should request text input" do
     @in.puts "bar"
     @in.rewind
-    @ui.request("foo").should == "bar"
-    @out.string.should == "foo"
+    expect(@ui.request("foo")).to eq("bar")
+    expect(@out.string).to eq("foo")
   end
   
   it "should ask for yes/no and return true when yes" do
@@ -55,27 +55,27 @@ describe RubyWarrior::UI do
   
   it "should present multiple options and return selected one" do
     @ui.expects(:request).with(includes('item')).returns('2')
-    @ui.choose('item', [:foo, :bar, :test]).should == :bar
-    @out.string.should include('[1] foo')
-    @out.string.should include('[2] bar')
-    @out.string.should include('[3] test')
+    expect(@ui.choose('item', [:foo, :bar, :test])).to eq(:bar)
+    expect(@out.string).to include('[1] foo')
+    expect(@out.string).to include('[2] bar')
+    expect(@out.string).to include('[3] test')
   end
   
   it "choose should accept array as option" do
     @ui.stubs(:request).returns('3')
-    @ui.choose('item', [:foo, :bar, [:tower, 'easy']]).should == :tower
-    @out.string.should include('[3] easy')
+    expect(@ui.choose('item', [:foo, :bar, [:tower, 'easy']])).to eq(:tower)
+    expect(@out.string).to include('[3] easy')
   end
   
   it "choose should return option without prompt if only one item" do
     @ui.expects(:puts).never
     @ui.expects(:gets).never
     @ui.stubs(:request).returns('3')
-    @ui.choose('item', [:foo]).should == :foo
+    expect(@ui.choose('item', [:foo])).to eq(:foo)
   end
   
   it "choose should return first value in array of option if only on item" do
-    @ui.choose('item', [[:foo, :bar]]).should == :foo
+    expect(@ui.choose('item', [[:foo, :bar]])).to eq(:foo)
   end
   
   it "should delay after puts when specified" do

--- a/spec/ruby_warrior/units/archer_spec.rb
+++ b/spec/ruby_warrior/units/archer_spec.rb
@@ -6,18 +6,18 @@ describe RubyWarrior::Units::Archer do
   end
   
   it "should have look and shoot abilities" do
-    @archer.abilities.keys.to_set.should == [:shoot!, :look].to_set
+    expect(@archer.abilities.keys.to_set).to eq([:shoot!, :look].to_set)
   end
   
   it "should have shoot power of 3" do
-    @archer.shoot_power.should == 3
+    expect(@archer.shoot_power).to eq(3)
   end
   
   it "should have 7 max health" do
-    @archer.max_health.should == 7
+    expect(@archer.max_health).to eq(7)
   end
   
   it "should appear as a on map" do
-    @archer.character.should == "a"
+    expect(@archer.character).to eq("a")
   end
 end

--- a/spec/ruby_warrior/units/base_spec.rb
+++ b/spec/ruby_warrior/units/base_spec.rb
@@ -6,47 +6,47 @@ describe RubyWarrior::Units::Base do
   end
   
   it "should have an attack power which defaults to zero" do
-    @unit.attack_power.should be_zero
+    expect(@unit.attack_power).to be_zero
   end
   
   it "should consider itself dead when no position" do
-    @unit.position.should be_nil
-    @unit.should_not be_alive
+    expect(@unit.position).to be_nil
+    expect(@unit).not_to be_alive
   end
   
   it "should consider itself alive with position" do
     @unit.position = stub
-    @unit.should be_alive
+    expect(@unit).to be_alive
   end
   
   it "should default max health to 10" do
-    @unit.max_health.should be_zero
+    expect(@unit.max_health).to be_zero
   end
   
   it "should do nothing when earning points" do
-    lambda { @unit.earn_points(10) }.should_not raise_error
+    expect(lambda { @unit.earn_points(10) }).not_to raise_error
   end
   
   it "should default health to max health" do
     @unit.stubs(:max_health).returns(10)
-    @unit.health.should == 10
+    expect(@unit.health).to eq(10)
   end
   
   it "should subtract health when taking damage" do
     @unit.stubs(:max_health).returns(10)
     @unit.take_damage(3)
-    @unit.health.should == 7
+    expect(@unit.health).to eq(7)
   end
   
   it "should do nothing when taking damage if health isn't set" do
-    lambda { @unit.take_damage(3) }.should_not raise_error
+    expect(lambda { @unit.take_damage(3) }).not_to raise_error
   end
   
   it "should set position to nil when running out of health" do
     @unit.position = stub
     @unit.stubs(:max_health).returns(10)
     @unit.take_damage(10)
-    @unit.position.should be_nil
+    expect(@unit.position).to be_nil
   end
   
   it "should print out line with name when speaking" do
@@ -55,8 +55,8 @@ describe RubyWarrior::Units::Base do
   end
   
   it "should return name in to_s" do
-    @unit.name.should == 'Base'
-    @unit.to_s.should == 'Base'
+    expect(@unit.name).to eq('Base')
+    expect(@unit.to_s).to eq('Base')
   end
   
   it "should prepare turn by calling play_turn with next turn object" do
@@ -87,37 +87,37 @@ describe RubyWarrior::Units::Base do
   
   it "should not raise an exception when calling perform_turn when there's no action" do
     @unit.prepare_turn
-    lambda { @unit.perform_turn }.should_not raise_error
+    expect(lambda { @unit.perform_turn }).not_to raise_error
   end
   
   it "should pass abilities to new turn when calling next_turn" do
     RubyWarrior::Turn.expects(:new).with(:walk! => nil, :attack! => nil, :feel => nil).returns('turn')
     @unit.stubs(:abilities).returns(:walk! => nil, :attack! => nil, :feel => nil)
-    @unit.next_turn.should == 'turn'
+    expect(@unit.next_turn).to eq('turn')
   end
   
   it "should add ability" do
     RubyWarrior::Abilities::Walk.expects(:new).with(@unit).returns('walk')
     @unit.add_abilities(:walk!)
-    @unit.abilities.should == { :walk! => 'walk' }
+    expect(@unit.abilities).to eq({ :walk! => 'walk' })
   end
   
   it "should appear as question mark on map" do
-    @unit.character.should == "?"
+    expect(@unit.character).to eq("?")
   end
   
   it "should be released from bonds when taking damage" do
     @unit.stubs(:max_health).returns(10)
     @unit.bind
-    @unit.should be_bound
+    expect(@unit).to be_bound
     @unit.take_damage(2)
-    @unit.should_not be_bound
+    expect(@unit).not_to be_bound
   end
   
   it "should be released from bonds when calling release" do
     @unit.bind
     @unit.unbind
-    @unit.should_not be_bound
+    expect(@unit).not_to be_bound
   end
   
   it "should not perform action when bound" do

--- a/spec/ruby_warrior/units/captive_spec.rb
+++ b/spec/ruby_warrior/units/captive_spec.rb
@@ -6,18 +6,18 @@ describe RubyWarrior::Units::Captive do
   end
   
   it "should have 1 max health" do
-    @captive.max_health.should == 1
+    expect(@captive.max_health).to eq(1)
   end
   
   it "should appear as C on map" do
-    @captive.character.should == "C"
+    expect(@captive.character).to eq("C")
   end
   
   it "should be bound by default" do
-    @captive.should be_bound
+    expect(@captive).to be_bound
   end
   
   it "should not have explode ability by default (this should be added when needed)" do
-    @captive.abilities.should_not include(:explode!)
+    expect(@captive.abilities).not_to include(:explode!)
   end
 end

--- a/spec/ruby_warrior/units/golem_spec.rb
+++ b/spec/ruby_warrior/units/golem_spec.rb
@@ -14,15 +14,15 @@ describe RubyWarrior::Units::Golem do
   
   it "should set max health and update current health" do
     @golem.max_health = 10
-    @golem.max_health.should == 10
-    @golem.health.should == 10
+    expect(@golem.max_health).to eq(10)
+    expect(@golem.health).to eq(10)
   end
   
   it "should have attack power of 3" do
-    @golem.attack_power.should == 3
+    expect(@golem.attack_power).to eq(3)
   end
   
   it "should appear as G on map" do
-    @golem.character.should == "G"
+    expect(@golem.character).to eq("G")
   end
 end

--- a/spec/ruby_warrior/units/sludge_spec.rb
+++ b/spec/ruby_warrior/units/sludge_spec.rb
@@ -6,22 +6,22 @@ describe RubyWarrior::Units::Sludge do
   end
   
   it "should have attack action" do
-    @sludge.abilities.keys.should include(:attack!)
+    expect(@sludge.abilities.keys).to include(:attack!)
   end
   
   it "should have feel sense" do
-    @sludge.abilities.keys.should include(:feel)
+    expect(@sludge.abilities.keys).to include(:feel)
   end
   
   it "should have attack power of 3" do
-    @sludge.attack_power.should == 3
+    expect(@sludge.attack_power).to eq(3)
   end
   
   it "should have 12 max health" do
-    @sludge.max_health.should == 12
+    expect(@sludge.max_health).to eq(12)
   end
   
   it "should appear as s on map" do
-    @sludge.character.should == "s"
+    expect(@sludge.character).to eq("s")
   end
 end

--- a/spec/ruby_warrior/units/thick_sludge_spec.rb
+++ b/spec/ruby_warrior/units/thick_sludge_spec.rb
@@ -6,14 +6,14 @@ describe RubyWarrior::Units::ThickSludge do
   end
   
   it "should have 24 max health" do
-    @sludge.max_health.should == 24
+    expect(@sludge.max_health).to eq(24)
   end
   
   it "should appear as S on map" do
-    @sludge.character.should == "S"
+    expect(@sludge.character).to eq("S")
   end
   
   it "should have the name of 'Thick Sludge'" do
-    @sludge.name.should == "Thick Sludge"
+    expect(@sludge.name).to eq("Thick Sludge")
   end
 end

--- a/spec/ruby_warrior/units/warrior_spec.rb
+++ b/spec/ruby_warrior/units/warrior_spec.rb
@@ -11,25 +11,25 @@ describe RubyWarrior::Units::Warrior do
   end
   
   it "should default name to warrior" do
-    @warrior.name.should == "Warrior"
+    expect(@warrior.name).to eq("Warrior")
     @warrior.name = ''
-    @warrior.name.should == "Warrior"
+    expect(@warrior.name).to eq("Warrior")
   end
   
   it "should be able to set name" do
     @warrior.name = "Joe"
-    @warrior.name.should == "Joe"
-    @warrior.to_s.should == "Joe"
+    expect(@warrior.name).to eq("Joe")
+    expect(@warrior.to_s).to eq("Joe")
   end
   
   it "should have 20 max health" do
-    @warrior.max_health.should == 20
+    expect(@warrior.max_health).to eq(20)
   end
   
   it "should have 0 score at beginning and be able to earn points" do
-    @warrior.score.should be_zero
+    expect(@warrior.score).to be_zero
     @warrior.earn_points(5)
-    @warrior.score.should == 5
+    expect(@warrior.score).to eq(5)
   end
   
   it "should call player.play_turn and pass turn to player" do
@@ -42,24 +42,24 @@ describe RubyWarrior::Units::Warrior do
   it "should call Player.new the first time loading player, and return same object next time" do
     Player.expects(:new).returns('player').times(1)
     2.times do
-      @warrior.player.should == 'player'
+      expect(@warrior.player).to eq('player')
     end
   end
   
   it "should have an attack power of 5" do
-    @warrior.attack_power.should == 5
+    expect(@warrior.attack_power).to eq(5)
   end
   
   it "should have an shoot power of 3" do
-    @warrior.shoot_power.should == 3
+    expect(@warrior.shoot_power).to eq(3)
   end
   
   it "should appear as @ on map" do
-    @warrior.character.should == "@"
+    expect(@warrior.character).to eq("@")
   end
   
   it "should be able to add golem abilities which are used on base golem" do
     @warrior.add_golem_abilities :walk!
-    @warrior.base_golem.abilities.keys.should == [:walk!]
+    expect(@warrior.base_golem.abilities.keys).to eq([:walk!])
   end
 end

--- a/spec/ruby_warrior/units/wizard_spec.rb
+++ b/spec/ruby_warrior/units/wizard_spec.rb
@@ -6,18 +6,18 @@ describe RubyWarrior::Units::Wizard do
   end
   
   it "should have look and shoot abilities" do
-    @wizard.abilities.keys.to_set.should == [:shoot!, :look].to_set
+    expect(@wizard.abilities.keys.to_set).to eq([:shoot!, :look].to_set)
   end
   
   it "should have shoot power of 11" do
-    @wizard.shoot_power.should == 11
+    expect(@wizard.shoot_power).to eq(11)
   end
   
   it "should have 3 max health" do
-    @wizard.max_health.should == 3
+    expect(@wizard.max_health).to eq(3)
   end
   
   it "should appear as w on map" do
-    @wizard.character.should == "w"
+    expect(@wizard.character).to eq("w")
   end
 end


### PR DESCRIPTION
I wasn't able to run tests out of the box, so I upgraded Rspec and started tracking my Gemfile.lock.

I changed "should" to "expect" to quiet deprecation warnings from Rspec. At first I did it by hand, but then went looking for scripts:

```
perl -p -i -e 's/^(\s+)(.*(?=.should))\.should(_)?(not)? (.*)$/$1expect($2).$4$3to $5/g' `find spec -name *.rb`

perl -p -i -e 's/ == (.*)$/ eq($1)/g' `find spec -name *.rb`
```

http://jakeboxer.com/blog/2012/07/09/converting-to-the-new-rspec-2-dot-11-expectation-syntax/

Please let me know what you would like to see done differently, but please try to let me know about as much as you can think of up front or any contribution rules or guidelines you might have as early as possible so I can avoid lots of rounds of revisions. (Had a bad experience with that recently.)
