### PR TITLE
Make runnable in Ruby 3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 tmp/**/*
+rubywarrior/*
 *.gem
 .project
 .buildpath

--- a/bin/rubywarrior
+++ b/bin/rubywarrior
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require File.dirname(__FILE__) + '/../lib/ruby_warrior'
+require_relative '../lib/ruby_warrior'
 
 runner = RubyWarrior::Runner.new(ARGV, STDIN, STDOUT)
 runner.run

--- a/lib/ruby_warrior/player_generator.rb
+++ b/lib/ruby_warrior/player_generator.rb
@@ -19,7 +19,7 @@ module RubyWarrior
     # TODO refactor and test this method
     def generate
       if level.number == 1
-        FileUtils.mkdir_p(level.player_path) unless File.exists? level.player_path
+        FileUtils.mkdir_p(level.player_path) unless File.exist? level.player_path
         FileUtils.cp(templates_path + '/player.rb', level.player_path)
       end
       

--- a/lib/ruby_warrior/player_generator.rb
+++ b/lib/ruby_warrior/player_generator.rb
@@ -35,7 +35,7 @@ module RubyWarrior
     private
     
     def read_template(path)
-      ERB.new(File.read(path), nil, '-').result(binding)
+      ERB.new(File.read(path), trim_mode: '-').result(binding)
     end
   end
 end


### PR DESCRIPTION
## Summary

- Makes the adjustments necessary for Ruby Warrior to run in Ruby 3.3.
- Adds the `rubywarrior` directory to `.gitignore` for the benefit of future contributors, because it's easy to accidentally include it in a commit.

## Specs are out of scope

I haven't similarly brought the specs up to date because that would make for a massive PR, requiring an upgrade to RSpec 3 with all its syntax changes. So I limited this PR to making it possible to run `rubywarrior` without errors or warnings.

## Screenshots

Here are the specific errors and warnings that this PR addresses.

#### Addressed in https://github.com/ryanb/ruby-warrior/commit/6dd5667da0d4fd8ae90e99f5087794e231aba3fd:

![require-error](https://github.com/ryanb/ruby-warrior/assets/9300391/f47d4658-0b76-493f-a882-4b2c4d52195e)

#### Addressed in https://github.com/ryanb/ruby-warrior/commit/94d73b55ccbf3d90e57f172974d1f915f8b58436:

![File-exists-error](https://github.com/ryanb/ruby-warrior/assets/9300391/53f6d8ce-a351-4260-bea1-7a96dc7ddee8)

#### Addressed in https://github.com/ryanb/ruby-warrior/commit/a5ae961ae5b4f4771e93ba9eb42dceadd4da6d0c:

![ERB-new-warning](https://github.com/ryanb/ruby-warrior/assets/9300391/3002546c-dbe7-48e0-b66d-3223504c4f7e)