### PR TITLE
Replace Mocha with RSpec mocks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,4 @@ group :test do
   gem 'rake'
   gem 'rspec', '~> 3.13.0'
   gem 'cucumber'
-  gem 'mocha'
 end

--- a/lib/ruby_warrior/level.rb
+++ b/lib/ruby_warrior/level.rb
@@ -113,7 +113,7 @@ module RubyWarrior
     def exists?
       File.exist? load_path
     end
-    
+
     def setup_warrior(warrior)
       @warrior = warrior
       @warrior.add_abilities(*profile.abilities)

--- a/spec/ruby_warrior/abilities/attack_spec.rb
+++ b/spec/ruby_warrior/abilities/attack_spec.rb
@@ -2,49 +2,49 @@ require 'spec_helper'
 
 describe RubyWarrior::Abilities::Attack do
   before(:each) do
-    @attacker = stub(:position => stub, :attack_power => 3, :say => nil)
+    @attacker = double(:position => double, :attack_power => 3, :say => nil)
     @attack = RubyWarrior::Abilities::Attack.new(@attacker)
   end
 
   it "should subtract attack power amount from health" do
     receiver = RubyWarrior::Units::Base.new
-    receiver.stubs(:alive?).returns(true)
+    allow(receiver).to receive(:alive?).and_return(true)
     receiver.health = 5
-    @attack.stubs(:unit).returns(receiver)
+    allow(@attack).to receive(:unit).and_return(receiver)
     @attack.perform
     expect(receiver.health).to eq(2)
   end
 
   it "should do nothing if recipient is nil" do
-    @attack.stubs(:unit).returns(nil)
+    allow(@attack).to receive(:unit).and_return(nil)
     expect { @attack.perform }.to_not raise_error
   end
 
   it "should get object at position from offset" do
-    @attacker.position.expects(:relative_space).with(1, 0)
+    expect(@attacker.position).to receive(:relative_space).with(1, 0)
     @attack.space(:forward)
   end
 
   it "should award points when killing unit" do
-    receiver = stub(:take_damage => nil, :max_health => 8, :alive? => false)
-    @attack.stubs(:unit).returns(receiver)
-    @attacker.expects(:earn_points).with(8)
+    receiver = double(:take_damage => nil, :max_health => 8, :alive? => false)
+    allow(@attack).to receive(:unit).and_return(receiver)
+    expect(@attacker).to receive(:earn_points).with(8)
     @attack.perform
   end
 
   it "should not award points when not killing unit" do
-    receiver = stub(:max_health => 8, :alive? => true)
-    receiver.expects(:take_damage)
-    @attack.stubs(:unit).returns(receiver)
-    @attacker.expects(:earn_points).never
+    receiver = double(:max_health => 8, :alive? => true)
+    expect(receiver).to receive(:take_damage)
+    allow(@attack).to receive(:unit).and_return(receiver)
+    expect(@attacker).to receive(:earn_points).never
     @attack.perform
   end
 
   it "should reduce attack power when attacking backward" do
     receiver = RubyWarrior::Units::Base.new
-    receiver.stubs(:alive?).returns(true)
+    allow(receiver).to receive(:alive?).and_return(true)
     receiver.health = 5
-    @attack.stubs(:unit).returns(receiver)
+    allow(@attack).to receive(:unit).and_return(receiver)
     @attack.perform(:backward)
     expect(receiver.health).to eq(3)
   end

--- a/spec/ruby_warrior/abilities/base_spec.rb
+++ b/spec/ruby_warrior/abilities/base_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe RubyWarrior::Abilities::Base do
   before(:each) do
-    @unit = stub
+    @unit = double
     @ability = RubyWarrior::Abilities::Base.new(@unit)
   end
 
@@ -22,7 +22,7 @@ describe RubyWarrior::Abilities::Base do
   end
 
   it "should fetch unit at given direction with distance" do
-    @ability.expects(:space).with(:right, 3, 1).returns(stub(:unit => 'unit'))
+    expect(@ability).to receive(:space).with(:right, 3, 1).and_return(double(:unit => 'unit'))
     expect(@ability.unit(:right, 3, 1)).to eq('unit')
   end
 

--- a/spec/ruby_warrior/abilities/bind_spec.rb
+++ b/spec/ruby_warrior/abilities/bind_spec.rb
@@ -2,18 +2,18 @@ require 'spec_helper'
 
 describe RubyWarrior::Abilities::Bind do
   before(:each) do
-    @bind = RubyWarrior::Abilities::Bind.new(stub(:say => nil))
+    @bind = RubyWarrior::Abilities::Bind.new(double(:say => nil))
   end
 
   it "should bind recipient" do
     receiver = RubyWarrior::Units::Base.new
-    @bind.stubs(:unit).returns(receiver)
+    allow(@bind).to receive(:unit).and_return(receiver)
     @bind.perform
     expect(receiver).to be_bound
   end
 
   it "should do nothing if no recipient" do
-    @bind.stubs(:unit).returns(nil)
+    allow(@bind).to receive(:unit).and_return(nil)
     expect { @bind.perform }.to_not raise_error
   end
 end

--- a/spec/ruby_warrior/abilities/direction_of_spec.rb
+++ b/spec/ruby_warrior/abilities/direction_of_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 describe RubyWarrior::Abilities::DirectionOf do
   before(:each) do
-    @position = stub
-    @distance = RubyWarrior::Abilities::DirectionOf.new(stub(:position => @position, :say => nil))
+    @position = double
+    @distance = RubyWarrior::Abilities::DirectionOf.new(double(:position => @position, :say => nil))
   end
 
   it "should return relative direction of given space" do
-    @position.stubs(:relative_direction_of).with(:space).returns(:left)
+    allow(@position).to receive(:relative_direction_of).with(:space).and_return(:left)
     expect(@distance.perform(:space)).to eq(:left)
   end
 end

--- a/spec/ruby_warrior/abilities/direction_of_stairs_spec.rb
+++ b/spec/ruby_warrior/abilities/direction_of_stairs_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 describe RubyWarrior::Abilities::DirectionOfStairs do
   before(:each) do
-    @position = stub
-    @distance = RubyWarrior::Abilities::DirectionOfStairs.new(stub(:position => @position, :say => nil))
+    @position = double
+    @distance = RubyWarrior::Abilities::DirectionOfStairs.new(double(:position => @position, :say => nil))
   end
 
   it "should return relative direction of stairs" do
-    @position.stubs(:relative_direction_of_stairs).returns(:left)
+    allow(@position).to receive(:relative_direction_of_stairs).and_return(:left)
     expect(@distance.perform).to eq(:left)
   end
 end

--- a/spec/ruby_warrior/abilities/distance_of_spec.rb
+++ b/spec/ruby_warrior/abilities/distance_of_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 describe RubyWarrior::Abilities::DistanceOf do
   before(:each) do
-    @position = stub
-    @distance = RubyWarrior::Abilities::DistanceOf.new(stub(:position => @position, :say => nil))
+    @position = double
+    @distance = RubyWarrior::Abilities::DistanceOf.new(double(:position => @position, :say => nil))
   end
 
   it "should return distance from stairs" do
-    @position.stubs(:distance_of).with(:space).returns(5)
+    allow(@position).to receive(:distance_of).with(:space).and_return(5)
     expect(@distance.perform(:space)).to eq(5)
   end
 end

--- a/spec/ruby_warrior/abilities/feel_spec.rb
+++ b/spec/ruby_warrior/abilities/feel_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 describe RubyWarrior::Abilities::Feel do
   before(:each) do
-    @unit = stub(:position => stub, :say => nil)
+    @unit = double(:position => double, :say => nil)
     @feel = RubyWarrior::Abilities::Feel.new(@unit)
   end
   
   it "should get object at position from offset" do
-    @unit.position.expects(:relative_space).with(1, 0)
+    expect(@unit.position).to receive(:relative_space).with(1, 0)
     @feel.perform(:forward)
   end
 end

--- a/spec/ruby_warrior/abilities/look_spec.rb
+++ b/spec/ruby_warrior/abilities/look_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe RubyWarrior::Abilities::Look do
   before(:each) do
-    @unit = stub(:position => stub, :say => nil)
+    @unit = double(:position => double, :say => nil)
     @feel = RubyWarrior::Abilities::Look.new(@unit)
   end
 
   it "should get 3 objects at position from offset" do
-    @unit.position.expects(:relative_space).with(1, 0).returns(1)
-    @unit.position.expects(:relative_space).with(2, 0).returns(2)
-    @unit.position.expects(:relative_space).with(3, 0).returns(3)
+    expect(@unit.position).to receive(:relative_space).with(1, 0).and_return(1)
+    expect(@unit.position).to receive(:relative_space).with(2, 0).and_return(2)
+    expect(@unit.position).to receive(:relative_space).with(3, 0).and_return(3)
     expect(@feel.perform(:forward)).to eq([1, 2, 3])
   end
 end

--- a/spec/ruby_warrior/abilities/pivot_spec.rb
+++ b/spec/ruby_warrior/abilities/pivot_spec.rb
@@ -2,17 +2,17 @@ require 'spec_helper'
 
 describe RubyWarrior::Abilities::Pivot do
   before(:each) do
-    @position = stub
-    @pivot = RubyWarrior::Abilities::Pivot.new(stub(:position => @position, :say => nil))
+    @position = double
+    @pivot = RubyWarrior::Abilities::Pivot.new(double(:position => @position, :say => nil))
   end
   
   it "should flip around when not passing arguments" do
-    @position.expects(:rotate).with(2)
+    expect(@position).to receive(:rotate).with(2)
     @pivot.perform
   end
   
   it "should rotate 1 when pivoting right" do
-    @position.expects(:rotate).with(1)
+    expect(@position).to receive(:rotate).with(1)
     @pivot.perform(:right)
   end
 end

--- a/spec/ruby_warrior/abilities/rescue_spec.rb
+++ b/spec/ruby_warrior/abilities/rescue_spec.rb
@@ -8,20 +8,20 @@ describe RubyWarrior::Abilities::Rescue do
 
   it "should rescue captive" do
     captive = RubyWarrior::Units::Captive.new
-    captive.position = stub
-    @rescue.expects(:space).with(:forward).returns(stub(:captive? => true))
-    @rescue.expects(:unit).with(:forward).returns(captive)
-    @warrior.expects(:earn_points).with(20)
+    captive.position = double
+    expect(@rescue).to receive(:space).with(:forward).and_return(double(:captive? => true))
+    expect(@rescue).to receive(:unit).with(:forward).and_return(captive)
+    expect(@warrior).to receive(:earn_points).with(20)
     @rescue.perform
     expect(captive.position).to be_nil
   end
 
   it "should do nothing to other unit if not bound" do
     unit = RubyWarrior::Units::Base.new
-    unit.position = stub
-    @rescue.expects(:space).with(:forward).returns(stub(:captive? => false))
-    @rescue.expects(:unit).with(:forward).never
-    @warrior.expects(:earn_points).never
+    unit.position = double
+    expect(@rescue).to receive(:space).with(:forward).and_return(double(:captive? => false))
+    expect(@rescue).to receive(:unit).with(:forward).never
+    expect(@warrior).to receive(:earn_points).never
     @rescue.perform
     expect(unit.position).to_not be_nil
   end
@@ -29,10 +29,10 @@ describe RubyWarrior::Abilities::Rescue do
   it "should release other unit when bound" do
     unit = RubyWarrior::Units::Base.new
     unit.bind
-    unit.position = stub
-    @rescue.expects(:space).with(:forward).returns(stub(:captive? => true))
-    @rescue.expects(:unit).with(:forward).returns(unit)
-    @warrior.expects(:earn_points).never
+    unit.position = double
+    expect(@rescue).to receive(:space).with(:forward).and_return(double(:captive? => true))
+    expect(@rescue).to receive(:unit).with(:forward).and_return(unit)
+    expect(@warrior).to receive(:earn_points).never
     @rescue.perform
     expect(unit).to_not be_bound
     expect(unit.position).to_not be_nil

--- a/spec/ruby_warrior/abilities/rest_spec.rb
+++ b/spec/ruby_warrior/abilities/rest_spec.rb
@@ -7,21 +7,21 @@ describe RubyWarrior::Abilities::Rest do
   end
 
   it "should give 10% health back" do
-    @warrior.stubs(:max_health).returns(20)
+    allow(@warrior).to receive(:max_health).and_return(20)
     @warrior.health = 10
     @rest.perform
     expect(@warrior.health).to eq(12)
   end
 
   it "should add health when at max" do
-    @warrior.stubs(:max_health).returns(20)
+    allow(@warrior).to receive(:max_health).and_return(20)
     @warrior.health = 20
     @rest.perform
     expect(@warrior.health).to eq(20)
   end
 
   it "should not go over max health" do
-    @warrior.stubs(:max_health).returns(20)
+    allow(@warrior).to receive(:max_health).and_return(20)
     @warrior.health = 19
     @rest.perform
     expect(@warrior.health).to eq(20)

--- a/spec/ruby_warrior/abilities/shoot_spec.rb
+++ b/spec/ruby_warrior/abilities/shoot_spec.rb
@@ -2,21 +2,21 @@ require 'spec_helper'
 
 describe RubyWarrior::Abilities::Shoot do
   before(:each) do
-    @shooter = stub(:position => stub, :shoot_power => 2, :say => nil)
+    @shooter = double(:position => double, :shoot_power => 2, :say => nil)
     @shoot = RubyWarrior::Abilities::Shoot.new(@shooter)
   end
 
   it "should shoot only first unit" do
-    receiver = stub(:alive? => true)
-    receiver.expects(:take_damage).with(2)
-    other = stub(:alive? => true)
-    other.expects(:take_damage).never
-    @shoot.expects(:multi_unit).with(:forward, anything).returns([nil, receiver, other, nil])
+    receiver = double(:alive? => true)
+    expect(receiver).to receive(:take_damage).with(2)
+    other = double(:alive? => true)
+    expect(other).to receive(:take_damage).never
+    expect(@shoot).to receive(:multi_unit).with(:forward, anything).and_return([nil, receiver, other, nil])
     @shoot.perform
   end
 
   it "should shoot and do nothing if no units in the way" do
-    @shoot.expects(:multi_unit).with(:forward, anything).returns([nil, nil])
+    expect(@shoot).to receive(:multi_unit).with(:forward, anything).and_return([nil, nil])
     expect { @shoot.perform }.to_not raise_error
   end
 end

--- a/spec/ruby_warrior/abilities/walk_spec.rb
+++ b/spec/ruby_warrior/abilities/walk_spec.rb
@@ -2,24 +2,24 @@ require 'spec_helper'
 
 describe RubyWarrior::Abilities::Walk do
   before(:each) do
-    @space = stub(:empty? => true, :unit => nil)
-    @position = stub(:relative_space => @space, :move => nil)
-    @walk = RubyWarrior::Abilities::Walk.new(stub(:position => @position, :say => nil))
+    @space = double(:empty? => true, :unit => nil)
+    @position = double(:relative_space => @space, :move => nil)
+    @walk = RubyWarrior::Abilities::Walk.new(double(:position => @position, :say => nil))
   end
 
   it "should move position forward when calling perform" do
-    @position.expects(:move).with(1, 0)
+    expect(@position).to receive(:move).with(1, 0)
     @walk.perform
   end
 
   it "should move position right if that is direction" do
-    @position.expects(:move).with(0, 1)
+    expect(@position).to receive(:move).with(0, 1)
     @walk.perform(:right)
   end
 
   it "should keep position if something is in the way" do
-    @position.stubs(:move).raises("shouldn't be called")
-    @space.stubs(:empty?).returns(false)
+    allow(@position).to receive(:move).and_raise("shouldn't be called")
+    allow(@space).to receive(:empty?).and_return(false)
     expect { @walk.perform(:right) }.to_not raise_error
   end
 end

--- a/spec/ruby_warrior/game_spec.rb
+++ b/spec/ruby_warrior/game_spec.rb
@@ -8,14 +8,14 @@ describe RubyWarrior::Game do
   # GAME DIR
 
   it "should make game directory if player says so" do
-    RubyWarrior::UI.stubs(:ask).returns(true)
-    Dir.expects(:mkdir).with('./rubywarrior')
+    allow(RubyWarrior::UI).to receive(:ask).and_return(true)
+    expect(Dir).to receive(:mkdir).with('./rubywarrior')
     @game.make_game_directory
   end
 
   it "should not make game and exit if player says no" do
-    RubyWarrior::UI.stubs(:ask).returns(false)
-    Dir.stubs(:mkdir).raises('should not be called')
+    allow(RubyWarrior::UI).to receive(:ask).and_return(false)
+    allow(Dir).to receive(:mkdir).and_raise('should not be called')
     expect { @game.make_game_directory }.to raise_error(SystemExit)
   end
 
@@ -23,43 +23,43 @@ describe RubyWarrior::Game do
   # PROFILES
 
   it "should load profiles for each profile path" do
-    RubyWarrior::Profile.expects(:load).with('foo/.profile').returns(1)
-    RubyWarrior::Profile.expects(:load).with('bar/.profile').returns(2)
-    @game.stubs(:profile_paths).returns(['foo/.profile', 'bar/.profile'])
+    expect(RubyWarrior::Profile).to receive(:load).with('foo/.profile').and_return(1)
+    expect(RubyWarrior::Profile).to receive(:load).with('bar/.profile').and_return(2)
+    allow(@game).to receive(:profile_paths).and_return(['foo/.profile', 'bar/.profile'])
     expect(@game.profiles).to eq([1, 2])
   end
 
   it "should find profile paths using Dir[] search" do
-    Dir.expects(:[]).with("./rubywarrior/**/.profile")
+    expect(Dir).to receive(:[]).with("./rubywarrior/**/.profile")
     @game.profile_paths
   end
 
   it "should try to create profile when no profile paths are specified" do
-    @game.stubs(:profiles).returns([])
-    @game.expects(:new_profile).returns('profile')
+    allow(@game).to receive(:profiles).and_return([])
+    expect(@game).to receive(:new_profile).and_return('profile')
     expect(@game.profile).to eq('profile')
   end
 
   it "should ask a player to choose a profile if multiple profiles are available, but only once" do
-    RubyWarrior::UI.expects(:choose).with('profile', [:profile1, [:new, 'New Profile']]).returns(:profile1)
-    @game.stubs(:profiles).returns([:profile1])
+    expect(RubyWarrior::UI).to receive(:choose).with('profile', [:profile1, [:new, 'New Profile']]).and_return(:profile1)
+    allow(@game).to receive(:profiles).and_return([:profile1])
     2.times { expect(@game.profile).to eq(:profile1) }
   end
 
   it "should ask user to choose a tower when creating a new profile" do
-    RubyWarrior::UI.stubs(:gets).returns('')
-    @game.stubs(:towers).returns([:tower1, :tower2])
-    RubyWarrior::UI.expects(:choose).with('tower', [:tower1, :tower2]).returns(stub(:path => '/foo/bar'))
+    allow(RubyWarrior::UI).to receive(:gets).and_return('')
+    allow(@game).to receive(:towers).and_return([:tower1, :tower2])
+    expect(RubyWarrior::UI).to receive(:choose).with('tower', [:tower1, :tower2]).and_return(double(path: '/foo/bar'))
     @game.new_profile
   end
 
   it "should pass name and selected tower to profile" do
-    profile = stub
-    RubyWarrior::UI.stubs(:choose).returns(stub(:path => 'tower_path'))
-    RubyWarrior::UI.stubs(:request).returns('name')
-    RubyWarrior::Profile.expects(:new).returns(profile)
-    profile.expects(:tower_path=).with('tower_path')
-    profile.expects(:warrior_name=).with('name')
+    profile = double
+    allow(RubyWarrior::UI).to receive(:choose).and_return(double(path: 'tower_path'))
+    allow(RubyWarrior::UI).to receive(:request).and_return('name')
+    expect(RubyWarrior::Profile).to receive(:new).and_return(profile)
+    expect(profile).to receive(:tower_path=).with('tower_path')
+    expect(profile).to receive(:warrior_name=).with('name')
     expect(@game.new_profile).to eq(profile)
   end
 
@@ -67,14 +67,14 @@ describe RubyWarrior::Game do
   # TOWERS
 
   it "load towers for each tower path" do
-    RubyWarrior::Tower.expects(:new).with('towers/foo').returns(1)
-    RubyWarrior::Tower.expects(:new).with('towers/bar').returns(2)
-    @game.stubs(:tower_paths).returns(['towers/foo', 'towers/bar'])
+    expect(RubyWarrior::Tower).to receive(:new).with('towers/foo').and_return(1)
+    expect(RubyWarrior::Tower).to receive(:new).with('towers/bar').and_return(2)
+    allow(@game).to receive(:tower_paths).and_return(['towers/foo', 'towers/bar'])
     expect(@game.towers).to eq([1, 2])
   end
 
   it "should find tower paths using Dir[] search" do
-    Dir.expects(:[]).with(File.expand_path('../../../towers/*', __FILE__))
+    expect(Dir).to receive(:[]).with(File.expand_path('../../../towers/*', __FILE__))
     @game.tower_paths
   end
 
@@ -82,21 +82,21 @@ describe RubyWarrior::Game do
   # LEVEL
 
   it "should fetch current level from profile and cache it" do
-    @game.stubs(:profile).returns(stub)
-    @game.profile.expects(:current_level).returns('foo')
+    allow(@game).to receive(:profile).and_return(double)
+    expect(@game.profile).to receive(:current_level).and_return('foo')
     2.times { expect(@game.current_level).to eq('foo') }
   end
 
   it "should fetch next level from profile and cache it" do
-    @game.stubs(:profile).returns(stub)
-    @game.profile.expects(:next_level).returns('bar')
+    allow(@game).to receive(:profile).and_return(double)
+    expect(@game.profile).to receive(:next_level).and_return('bar')
     2.times { expect(@game.next_level).to eq('bar') }
   end
 
   it "should report final grade" do
     profile = RubyWarrior::Profile.new
     profile.current_epic_grades = { 1 => 0.7, 2 => 0.9 }
-    @game.stubs(:profile).returns(profile)
+    allow(@game).to receive(:profile).and_return(profile)
     report = @game.final_report
     expect(report).to include("Your average grade for this tower is: B")
     expect(report).to include("Level 1: C\n  Level 2: A")
@@ -105,7 +105,7 @@ describe RubyWarrior::Game do
   it "should have an empty final report if no epic grades are available" do
     profile = RubyWarrior::Profile.new
     profile.current_epic_grades = {}
-    @game.stubs(:profile).returns(profile)
+    allow(@game).to receive(:profile).and_return(profile)
     expect(@game.final_report).to be_nil
   end
 
@@ -113,7 +113,7 @@ describe RubyWarrior::Game do
     RubyWarrior::Config.practice_level = 2
     profile = RubyWarrior::Profile.new
     profile.current_epic_grades = { 1 => 0.7, 2 => 0.9 }
-    @game.stubs(:profile).returns(profile)
+    allow(@game).to receive(:profile).and_return(profile)
     expect(@game.final_report).to be_nil
   end
 end

--- a/spec/ruby_warrior/level_loader_spec.rb
+++ b/spec/ruby_warrior/level_loader_spec.rb
@@ -24,7 +24,7 @@ describe RubyWarrior::LevelLoader do
     end
 
     it "should be able to add stairs" do
-      @level.floor.expects(:place_stairs).with(1, 2)
+      expect(@level.floor).to receive(:place_stairs).with(1, 2)
       @loader.stairs 1, 2
     end
 

--- a/spec/ruby_warrior/level_spec.rb
+++ b/spec/ruby_warrior/level_spec.rb
@@ -7,7 +7,7 @@ describe RubyWarrior::Level do
     @floor = RubyWarrior::Floor.new
     @level = RubyWarrior::Level.new(@profile, 1)
     @level.floor = @floor
-    @level.stubs(:failed?).returns(false)
+    allow(@level).to receive(:failed?).and_return(false)
   end
 
   it "should consider passed when warrior is on stairs" do
@@ -38,80 +38,80 @@ describe RubyWarrior::Level do
   end
 
   it "should load file contents into level" do
-    @level.stubs(:load_path).returns('path/to/level.rb')
-    File.expects(:read).with('path/to/level.rb').returns("description 'foo'")
+    allow(@level).to receive(:load_path).and_return('path/to/level.rb')
+    expect(File).to receive(:read).with('path/to/level.rb').and_return("description 'foo'")
     @level.load_level
     expect(@level.description).to eq('foo')
   end
 
   it "should have a player path from profile" do
-    @profile.stubs(:player_path).returns('path/to/player')
+    allow(@profile).to receive(:player_path).and_return('path/to/player')
     expect(@level.player_path).to eq('path/to/player')
   end
 
   it "should have a load path from profile tower with level number in it" do
-    @profile.stubs(:tower_path).returns('path/to/tower')
+    allow(@profile).to receive(:tower_path).and_return('path/to/tower')
     expect(@level.load_path).to eq(File.expand_path('towers/tower/level_001.rb'))
   end
 
   it "should exist if file exists" do
-    @level.stubs(:load_path).returns('/foo/bar')
-    File.expects(:exist?).with('/foo/bar').returns(true)
+    allow(@level).to receive(:load_path).and_return('/foo/bar')
+    expect(File).to receive(:exist?).with('/foo/bar').and_return(true)
     expect(@level.exists?).to eq(true)
   end
 
   it "should load player and player path" do
-    @level.stubs(:player_path).returns('player/path')
-    $:.expects(:<<).with('player/path')
-    @level.expects(:load).with('player.rb')
+    allow(@level).to receive(:player_path).and_return('player/path')
+    expect($:).to receive(:<<).with('player/path')
+    expect(@level).to receive(:load).with('player.rb')
     @level.load_player
   end
 
   it "should generate player files" do
-    @level.expects(:load_level)
-    generator = stub
-    generator.expects(:generate)
-    RubyWarrior::PlayerGenerator.expects(:new).with(@level).returns(generator)
+    expect(@level).to receive(:load_level)
+    generator = double
+    expect(generator).to receive(:generate)
+    expect(RubyWarrior::PlayerGenerator).to receive(:new).with(@level).and_return(generator)
     @level.generate_player_files
   end
 
   it "should setup warrior with profile abilities" do
     @profile.abilities = [:foo, :bar]
-    warrior = stub_everything
-    warrior.expects(:add_abilities).with(:foo, :bar)
+    warrior = double.as_null_object
+    expect(warrior).to receive(:add_abilities).with(:foo, :bar)
     @level.setup_warrior(warrior)
   end
 
   it "should setup warrior with profile name" do
     @profile.warrior_name = "Joe"
-    warrior = stub_everything
-    warrior.expects(:name=).with("Joe")
+    warrior = double.as_null_object
+    expect(warrior).to receive(:name=).with("Joe")
     @level.setup_warrior(warrior)
   end
 
   describe "playing" do
     before(:each) do
-      @level.stubs(:load_level)
+      allow(@level).to receive(:load_level)
     end
 
     it "should load level once when playing multiple turns" do
-      @level.expects(:load_level)
+      expect(@level).to receive(:load_level)
       @level.play(2)
     end
 
     it "should call prepare_turn and play_turn on each object specified number of times" do
       object = RubyWarrior::Units::Base.new
-      object.expects(:prepare_turn).times(2)
-      object.expects(:perform_turn).times(2)
+      expect(object).to receive(:prepare_turn).exactly(2).times
+      expect(object).to receive(:perform_turn).exactly(2).times
       @floor.add(object, 0, 0, :north)
       @level.play(2)
     end
 
     it "should return immediately when passed" do
       object = RubyWarrior::Units::Base.new
-      object.expects(:turn).times(0)
+      expect(object).not_to receive(:turn)
       @floor.add(object, 0, 0, :north)
-      @level.stubs(:passed?).returns(true)
+      allow(@level).to receive(:passed?).and_return(true)
       @level.play(2)
     end
 
@@ -146,20 +146,20 @@ describe RubyWarrior::Level do
 
   describe "tallying points" do
     before(:each) do
-      @warrior = stub(:score => 0, :abilities => {})
-      @level.stubs(:warrior).returns(@warrior)
-      @level.floor.stubs(:other_units).returns([stub])
+      @warrior = double(:score => 0, :abilities => {})
+      allow(@level).to receive(:warrior).and_return(@warrior)
+      allow(@level.floor).to receive(:other_units).and_return([double])
     end
 
     it "should add warrior score to profile" do
-      @warrior.stubs(:score).returns(30)
+      allow(@warrior).to receive(:score).and_return(30)
       @level.tally_points
       expect(@profile.score).to eq(30)
     end
 
     it "should add warrior score to profile for epic mode" do
       @profile.enable_epic_mode
-      @warrior.stubs(:score).returns(30)
+      allow(@warrior).to receive(:score).and_return(30)
       @level.tally_points
       expect(@profile.current_epic_score).to eq(30)
     end
@@ -167,7 +167,7 @@ describe RubyWarrior::Level do
     it "should add level grade percent to profile for epic mode" do
       @level.ace_score = 100
       @profile.enable_epic_mode
-      @warrior.stubs(:score).returns(30)
+      allow(@warrior).to receive(:score).and_return(30)
       @level.tally_points
       expect(@profile.current_epic_grades).to eq({ 1 => 0.3 })
     end
@@ -175,13 +175,13 @@ describe RubyWarrior::Level do
     it "should not add level grade if ace score is not set" do
       @level.ace_score = nil
       @profile.enable_epic_mode
-      @warrior.stubs(:score).returns(30)
+      allow(@warrior).to receive(:score).and_return(30)
       @level.tally_points
       expect(@profile.current_epic_grades).to eq({})
     end
 
     it "should apply warrior abilities to profile" do
-      @warrior.stubs(:abilities).returns({:foo => nil, :bar => nil})
+      allow(@warrior).to receive(:abilities).and_return({:foo => nil, :bar => nil})
       @level.tally_points
       expect(@profile.abilities.to_set).to eq([:foo, :bar].to_set)
     end
@@ -193,8 +193,8 @@ describe RubyWarrior::Level do
     end
 
     it "should give 20% bonus when no other units left" do
-      @level.floor.stubs(:other_units).returns([])
-      @warrior.stubs(:score).returns(10)
+      allow(@level.floor).to receive(:other_units).and_return([])
+      allow(@warrior).to receive(:score).and_return(10)
       @level.time_bonus = 10
       @level.tally_points
       expect(@profile.score).to eq(24)

--- a/spec/ruby_warrior/profile_spec.rb
+++ b/spec/ruby_warrior/profile_spec.rb
@@ -36,9 +36,9 @@ describe RubyWarrior::Profile do
 
   it "load should read file, decode and set player path" do
     profile = 'profile'
-    profile.expects(:player_path=).with('path/to')
-    File.expects(:read).with('path/to/.profile').returns('encoded_profile')
-    RubyWarrior::Profile.expects(:decode).with('encoded_profile').returns(profile)
+    expect(profile).to receive(:player_path=).with('path/to')
+    expect(File).to receive(:read).with('path/to/.profile').and_return('encoded_profile')
+    expect(RubyWarrior::Profile).to receive(:decode).with('encoded_profile').and_return(profile)
     expect(RubyWarrior::Profile.load('path/to/.profile')).to eq(profile)
   end
 
@@ -129,10 +129,10 @@ describe RubyWarrior::Profile do
     end
 
     it "save should write file with encoded profile" do
-      file = stub
-      file.expects(:write).with('encoded_profile')
-      File.expects(:open).with(@profile.player_path + '/.profile', 'w').yields(file)
-      @profile.expects(:encode).returns('encoded_profile')
+      file = double
+      expect(file).to receive(:write).with('encoded_profile')
+      expect(File).to receive(:open).with(@profile.player_path + '/.profile', 'w').and_yield(file)
+      expect(@profile).to receive(:encode).and_return('encoded_profile')
       @profile.save
     end
 
@@ -164,7 +164,7 @@ describe RubyWarrior::Profile do
     end
 
     it "should load tower from path" do
-      RubyWarrior::Tower.expects(:new).with('tower').returns('tower')
+      expect(RubyWarrior::Tower).to receive(:new).with('tower').and_return('tower')
       expect(@profile.tower).to eq('tower')
     end
   end

--- a/spec/ruby_warrior/turn_spec.rb
+++ b/spec/ruby_warrior/turn_spec.rb
@@ -29,8 +29,8 @@ describe RubyWarrior::Turn do
   describe "with senses" do
     before(:each) do
       @feel = RubyWarrior::Abilities::Feel.new(Object.new)
-      @feel.stubs(:space).returns(Object.new)
-      @feel.stubs(:space).with(:backward).returns(Object.new)
+      allow(@feel).to receive(:space).and_return(Object.new)
+      allow(@feel).to receive(:space).with(:backward).and_return(Object.new)
       @turn = RubyWarrior::Turn.new({:feel => @feel})
     end
 

--- a/spec/ruby_warrior/ui_spec.rb
+++ b/spec/ruby_warrior/ui_spec.rb
@@ -39,22 +39,22 @@ describe RubyWarrior::UI do
   end
 
   it "should ask for yes/no and return true when yes" do
-    @ui.expects(:request).with('foo? [yn] ').returns('y')
+    expect(@ui).to receive(:request).with('foo? [yn] ').and_return('y')
     expect(@ui.ask("foo?")).to eq(true)
   end
 
   it "should ask for yes/no and return false when no" do
-    @ui.stubs(:request).returns('n')
+    allow(@ui).to receive(:request).and_return('n')
     expect(@ui.ask("foo?")).to eq(false)
   end
 
   it "should ask for yes/no and return false for any input" do
-    @ui.stubs(:request).returns('aklhasdf')
+    allow(@ui).to receive(:request).and_return('aklhasdf')
     expect(@ui.ask("foo?")).to eq(false)
   end
 
   it "should present multiple options and return selected one" do
-    @ui.expects(:request).with(includes('item')).returns('2')
+    expect(@ui).to receive(:request).with(include('item')).and_return('2')
     expect(@ui.choose('item', [:foo, :bar, :test])).to eq(:bar)
     expect(@out.string).to include('[1] foo')
     expect(@out.string).to include('[2] bar')
@@ -62,15 +62,15 @@ describe RubyWarrior::UI do
   end
 
   it "choose should accept array as option" do
-    @ui.stubs(:request).returns('3')
+    allow(@ui).to receive(:request).and_return('3')
     expect(@ui.choose('item', [:foo, :bar, [:tower, 'easy']])).to eq(:tower)
     expect(@out.string).to include('[3] easy')
   end
 
   it "choose should return option without prompt if only one item" do
-    @ui.expects(:puts).never
-    @ui.expects(:gets).never
-    @ui.stubs(:request).returns('3')
+    expect(@ui).to receive(:puts).never
+    expect(@ui).to receive(:gets).never
+    allow(@ui).to receive(:request).and_return('3')
     expect(@ui.choose('item', [:foo])).to eq(:foo)
   end
 
@@ -80,14 +80,14 @@ describe RubyWarrior::UI do
 
   it "should delay after puts when specified" do
     @config.delay = 1.3
-    @ui.expects(:puts).with("foo")
-    @ui.expects(:sleep).with(1.3)
+    expect(@ui).to receive(:puts).with("foo")
+    expect(@ui).to receive(:sleep).with(1.3)
     @ui.puts_with_delay("foo")
   end
 
   it "should not delay puts when delay isn't specified" do
-    @ui.expects(:puts).with("foo")
-    @ui.expects(:sleep).never
+    expect(@ui).to receive(:puts).with("foo")
+    expect(@ui).to receive(:sleep).never
     @ui.puts_with_delay("foo")
   end
 end

--- a/spec/ruby_warrior/units/base_spec.rb
+++ b/spec/ruby_warrior/units/base_spec.rb
@@ -15,7 +15,7 @@ describe RubyWarrior::Units::Base do
   end
 
   it "should consider itself alive with position" do
-    @unit.position = stub
+    @unit.position = double
     expect(@unit).to be_alive
   end
 
@@ -28,12 +28,12 @@ describe RubyWarrior::Units::Base do
   end
 
   it "should default health to max health" do
-    @unit.stubs(:max_health).returns(10)
+    allow(@unit).to receive(:max_health).and_return(10)
     expect(@unit.health).to eq(10)
   end
 
   it "should subtract health when taking damage" do
-    @unit.stubs(:max_health).returns(10)
+    allow(@unit).to receive(:max_health).and_return(10)
     @unit.take_damage(3)
     expect(@unit.health).to eq(7)
   end
@@ -43,14 +43,14 @@ describe RubyWarrior::Units::Base do
   end
 
   it "should set position to nil when running out of health" do
-    @unit.position = stub
-    @unit.stubs(:max_health).returns(10)
+    @unit.position = double
+    allow(@unit).to receive(:max_health).and_return(10)
     @unit.take_damage(10)
     expect(@unit.position).to be_nil
   end
 
   it "should print out line with name when speaking" do
-    RubyWarrior::UI.expects(:puts_with_delay).with("Base foo")
+    expect(RubyWarrior::UI).to receive(:puts_with_delay).with("Base foo")
     @unit.say "foo"
   end
 
@@ -60,27 +60,27 @@ describe RubyWarrior::Units::Base do
   end
 
   it "should prepare turn by calling play_turn with next turn object" do
-    @unit.stubs(:next_turn).returns('next_turn')
-    @unit.expects(:play_turn).with('next_turn')
+    allow(@unit).to receive(:next_turn).and_return('next_turn')
+    expect(@unit).to receive(:play_turn).with('next_turn')
     @unit.prepare_turn
   end
 
   it "should perform action when calling perform on turn" do
-    @unit.position = stub
-    RubyWarrior::Abilities::Walk.any_instance.expects(:perform).with(:backward)
+    @unit.position = double
+    expect_any_instance_of(RubyWarrior::Abilities::Walk).to receive(:perform).with(:backward)
     @unit.add_abilities(:walk!)
-    turn = stub(:action => [:walk!, :backward])
-    @unit.stubs(:next_turn).returns(turn)
+    turn = double(:action => [:walk!, :backward])
+    allow(@unit).to receive(:next_turn).and_return(turn)
     @unit.prepare_turn
     @unit.perform_turn
   end
 
   it "should not perform action when dead (no position)" do
     @unit.position = nil
-    RubyWarrior::Abilities::Walk.any_instance.stubs(:perform).raises("action should not be called")
+    allow_any_instance_of(RubyWarrior::Abilities::Walk).to receive(:perform).and_raise("action should not be called")
     @unit.add_abilities(:walk!)
-    turn = stub(:action => [:walk!, :backward])
-    @unit.stubs(:next_turn).returns(turn)
+    turn = double(:action => [:walk!, :backward])
+    allow(@unit).to receive(:next_turn).and_return(turn)
     @unit.prepare_turn
     @unit.perform_turn
   end
@@ -91,13 +91,13 @@ describe RubyWarrior::Units::Base do
   end
 
   it "should pass abilities to new turn when calling next_turn" do
-    RubyWarrior::Turn.expects(:new).with({:walk! => nil, :attack! => nil, :feel => nil}).returns('turn')
-    @unit.stubs(:abilities).returns(:walk! => nil, :attack! => nil, :feel => nil)
+    expect(RubyWarrior::Turn).to receive(:new).with(:walk! => nil, :attack! => nil, :feel => nil).and_return('turn')
+    allow(@unit).to receive(:abilities).and_return(:walk! => nil, :attack! => nil, :feel => nil)
     expect(@unit.next_turn).to eq('turn')
   end
 
   it "should add ability" do
-    RubyWarrior::Abilities::Walk.expects(:new).with(@unit).returns('walk')
+    expect(RubyWarrior::Abilities::Walk).to receive(:new).with(@unit).and_return('walk')
     @unit.add_abilities(:walk!)
     expect(@unit.abilities).to eq({ :walk! => 'walk' })
   end
@@ -107,7 +107,7 @@ describe RubyWarrior::Units::Base do
   end
 
   it "should be released from bonds when taking damage" do
-    @unit.stubs(:max_health).returns(10)
+    allow(@unit).to receive(:max_health).and_return(10)
     @unit.bind
     expect(@unit).to be_bound
     @unit.take_damage(2)
@@ -121,12 +121,12 @@ describe RubyWarrior::Units::Base do
   end
 
   it "should not perform action when bound" do
-    @unit.position = stub
+    @unit.position = double
     @unit.bind
-    RubyWarrior::Abilities::Walk.any_instance.stubs(:perform).raises("action should not be called")
+    allow_any_instance_of(RubyWarrior::Abilities::Walk).to receive(:perform).and_raise("action should not be called")
     @unit.add_abilities(:walk!)
-    turn = stub(:action => [:walk!, :backward])
-    @unit.stubs(:next_turn).returns(turn)
+    turn = double(:action => [:walk!, :backward])
+    allow(@unit).to receive(:next_turn).and_return(turn)
     @unit.prepare_turn
     @unit.perform_turn
   end

--- a/spec/ruby_warrior/units/golem_spec.rb
+++ b/spec/ruby_warrior/units/golem_spec.rb
@@ -7,7 +7,7 @@ describe RubyWarrior::Units::Golem do
 
   it "should execute turn proc when playing turn" do
     proc = Object.new
-    proc.expects(:call).with(:turn)
+    expect(proc).to receive(:call).with(:turn)
     @golem.turn = proc
     @golem.play_turn(:turn)
   end

--- a/spec/ruby_warrior/units/warrior_spec.rb
+++ b/spec/ruby_warrior/units/warrior_spec.rb
@@ -33,14 +33,14 @@ describe RubyWarrior::Units::Warrior do
   end
 
   it "should call player.play_turn and pass turn to player" do
-    player = stub
-    player.expects(:play_turn).with('turn')
-    @warrior.stubs(:player).returns(player)
+    player = double
+    expect(player).to receive(:play_turn).with('turn')
+    allow(@warrior).to receive(:player).and_return(player)
     @warrior.play_turn('turn')
   end
 
   it "should call Player.new the first time loading player, and return same object next time" do
-    Player.expects(:new).returns('player').times(1)
+    expect(Player).to receive(:new).and_return('player').once
     2.times do
       expect(@warrior.player).to eq('player')
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,6 @@ require 'rspec'
 require File.dirname(__FILE__) + '/../lib/ruby_warrior'
 
 RSpec.configure do |config|
-  config.mock_with :mocha
   config.before(:each) do
     RubyWarrior::Config.reset
   end


### PR DESCRIPTION
Now that RSpec 3 is being used, RSpec mocks can take the place of Mocha.